### PR TITLE
Fix/cycle view and notification tap

### DIFF
--- a/SkincareTracker.xcodeproj/project.pbxproj
+++ b/SkincareTracker.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		AABBCCDDEEFF112233445566 /* AddToCycleSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 112233445566778899AABBCC /* AddToCycleSheet.swift */; };
 		50D4C32BA908C4E6F7C85868 /* ReminderConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = A78EAA39EB47AD86BE7867A7 /* ReminderConfig.swift */; };
 		52EEAAF9DF6E84DFD152C350 /* SkincareTrackerApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = A73038CA622F55888E53CEE9 /* SkincareTrackerApp.swift */; };
+		A1P2P3D4E5L6E7G8A9T0E2 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1P2P3D4E5L6E7G8A9T0E1 /* AppDelegate.swift */; };
 		60A4FCE1C61FBBBBAC4B09DE /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 72076678EDAFFA62005D8DC9 /* Assets.xcassets */; };
 		713D831DA5728E9DEB40202B /* ProductsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C4550BBFC4C13454DC5FCA9 /* ProductsView.swift */; };
 		75EE04963A079A11531017EE /* RemindersView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 769A7F0776C822F50B8C737B /* RemindersView.swift */; };
@@ -61,6 +62,7 @@
 		891956B70E0F834744305A1D /* SkincareTracker.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SkincareTracker.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		9C4550BBFC4C13454DC5FCA9 /* ProductsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsView.swift; sourceTree = "<group>"; };
 		A73038CA622F55888E53CEE9 /* SkincareTrackerApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkincareTrackerApp.swift; sourceTree = "<group>"; };
+		A1P2P3D4E5L6E7G8A9T0E1 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		A78EAA39EB47AD86BE7867A7 /* ReminderConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReminderConfig.swift; sourceTree = "<group>"; };
 		112233445566778899AABBCC /* AddToCycleSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddToCycleSheet.swift; sourceTree = "<group>"; };
 		B2D6154E783D16AD56331501 /* CycleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CycleView.swift; sourceTree = "<group>"; };
@@ -229,6 +231,7 @@
 				72076678EDAFFA62005D8DC9 /* Assets.xcassets */,
 				6694A83B5AE99446F1BA5117 /* Info.plist */,
 				A73038CA622F55888E53CEE9 /* SkincareTrackerApp.swift */,
+				A1P2P3D4E5L6E7G8A9T0E1 /* AppDelegate.swift */,
 				80DF87551BA248D87B4F778C /* AppState */,
 				1685A7409A382493A7E7FE40 /* Design */,
 				B2C0B53E4AD25386C7E224DA /* Models */,
@@ -367,6 +370,7 @@
 				985D0CAD9A464C6363E59C08 /* ScheduleItem.swift in Sources */,
 				FC8C798F93A105648A1727FF /* ScheduleView.swift in Sources */,
 				52EEAAF9DF6E84DFD152C350 /* SkincareTrackerApp.swift in Sources */,
+				A1P2P3D4E5L6E7G8A9T0E2 /* AppDelegate.swift in Sources */,
 				E3AB67C5D50261FCDACAB3B2 /* TodayView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/SkincareTracker/AppDelegate.swift
+++ b/SkincareTracker/AppDelegate.swift
@@ -1,0 +1,48 @@
+//
+//  AppDelegate.swift
+//  SkincareTracker
+//
+//  Handles notification taps to open the Today tab.
+//
+
+import UIKit
+import UserNotifications
+
+extension Notification.Name {
+    static let openTodayTab = Notification.Name("openTodayTab")
+    static let openCycleTab = Notification.Name("openCycleTab")
+}
+
+let openTodayTabKey = "com.skincaretracker.openTodayTab"
+let openCycleTabKey = "com.skincaretracker.openCycleTab"
+
+final class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDelegate {
+
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+    ) -> Bool {
+        UNUserNotificationCenter.current().delegate = self
+        return true
+    }
+
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse,
+        withCompletionHandler completionHandler: @escaping () -> Void
+    ) {
+        let isNoRoutine = (response.notification.request.content.userInfo["noRoutine"] as? Bool) == true
+        if isNoRoutine {
+            UserDefaults.standard.set(true, forKey: openCycleTabKey)
+            DispatchQueue.main.async {
+                NotificationCenter.default.post(name: .openCycleTab, object: nil)
+            }
+        } else {
+            UserDefaults.standard.set(true, forKey: openTodayTabKey)
+            DispatchQueue.main.async {
+                NotificationCenter.default.post(name: .openTodayTab, object: nil)
+            }
+        }
+        completionHandler()
+    }
+}

--- a/SkincareTracker/AppState/AppStore.swift
+++ b/SkincareTracker/AppState/AppStore.swift
@@ -28,6 +28,11 @@ final class AppStore: ObservableObject {
         products.sorted { $0.name < $1.name }
     }
 
+    /// Products for the Products tab: cycle products first (in cycle order), then rest alphabetically.
+    var productsForListView: [Product] {
+        productsInCycleOrdered + productsNotInCycle
+    }
+
     /// Products that have been added to the cycle. Sorted by name.
     var productsInCycle: [Product] {
         products.filter { cycleProductOrder.contains($0.id) }.sorted { $0.name < $1.name }

--- a/SkincareTracker/AppState/AppStore.swift
+++ b/SkincareTracker/AppState/AppStore.swift
@@ -119,6 +119,22 @@ final class AppStore: ObservableObject {
     
     // MARK: - Products
     
+    /// Returns true if a product with the same name and category already exists.
+    /// - Parameters:
+    ///   - name: Product name (compared case-insensitively).
+    ///   - categoryId: Category id; nil is treated as "other".
+    ///   - excludingProductId: If set, this product is excluded (for edits).
+    func hasDuplicateProduct(name: String, categoryId: String?, excludingProductId: UUID? = nil) -> Bool {
+        let normalizedName = name.trimmingCharacters(in: .whitespaces).lowercased()
+        let catId = categoryId ?? "other"
+        guard !normalizedName.isEmpty else { return false }
+        return products.contains { p in
+            p.id != excludingProductId &&
+            p.name.lowercased() == normalizedName &&
+            (p.categoryId ?? "other") == catId
+        }
+    }
+    
     /// Adds a product and rebuilds the schedule.
     /// - Parameter product: The product to add.
     func addProduct(_ product: Product) {

--- a/SkincareTracker/Models/INCIIngredients.swift
+++ b/SkincareTracker/Models/INCIIngredients.swift
@@ -259,11 +259,37 @@ enum INCIIngredients {
     }
 
     /// Normalizes OCR or pasted text (newlines, semicolons) to comma-separated form for parsing.
+    /// Strips common label headers like "INGREDIENTS" that OCR often captures.
+    /// - Newline after comma = delimiter between ingredients
+    /// - Newline without comma = line wrap (ingredient name continues on next line)
     static func normalizeForParsing(_ text: String) -> String {
-        text
-            .replacingOccurrences(of: "\n", with: ", ")
-            .replacingOccurrences(of: ";", with: ", ")
-            .replacingOccurrences(of: "  ", with: " ")
+        var result = text
+            .replacingOccurrences(of: "\r\n", with: "\n")
+            .replacingOccurrences(of: "\r", with: "\n")
+        // Comma + newline = delimiter between ingredients
+        result = result.replacingOccurrences(of: ",\\s*\\n", with: ", ", options: .regularExpression)
+        // Newline without comma = line wrap (ingredient continues on next line)
+        result = result.replacingOccurrences(of: "\n", with: " ")
+        result = result.replacingOccurrences(of: ";", with: ", ")
+        // Collapse multiple commas and normalize spacing
+        while result.contains(",,") || result.contains(", ,") {
+            result = result.replacingOccurrences(of: ", ,", with: ",")
+            result = result.replacingOccurrences(of: ",,", with: ",")
+        }
+        result = result.replacingOccurrences(of: "  ", with: " ")
+        // Remove common label headers that OCR captures (case-insensitive)
+        let headersToStrip = ["INGREDIENTS:", "INGREDIENTS", "INGREDIENT LIST:", "INGREDIENT LIST"]
+        for header in headersToStrip {
+            if let range = result.range(of: header, options: .caseInsensitive) {
+                result.removeSubrange(range)
+                result = result.trimmingCharacters(in: .whitespaces)
+                if result.hasPrefix(",") || result.hasPrefix(":") {
+                    result = String(result.dropFirst()).trimmingCharacters(in: .whitespaces)
+                }
+                break
+            }
+        }
+        return result
     }
 
     /// Converts a single raw name (without concentration) to its INCI form.

--- a/SkincareTracker/Services/ReminderService.swift
+++ b/SkincareTracker/Services/ReminderService.swift
@@ -46,6 +46,9 @@ final class ReminderService: ObservableObject {
             content.title = params.title
             content.body = params.body
             content.sound = .default
+            if products.isEmpty {
+                content.userInfo = ["noRoutine": true]
+            }
             var dateComponents = DateComponents()
             dateComponents.hour = params.hour
             dateComponents.minute = params.minute
@@ -66,14 +69,15 @@ final class ReminderService: ObservableObject {
         healthWakeTime: (hour: Int, minute: Int)?,
         healthBedtime: (hour: Int, minute: Int)?
     ) -> (body: String, title: String, hour: Int, minute: Int, identifier: String) {
-        let routineLabel = config.routineType.rawValue.lowercased()
-        let greeting = config.routineType == .morning ? "Good morning" : "Good night"
-        let productList = products.map(\.name).joined(separator: ", ")
-        let routinePart = productList.isEmpty
-            ? "Here is your \(routineLabel) skincare routine."
-            : "Here is your \(routineLabel) skincare routine: \(productList)."
-        let body = "\(greeting), \(routinePart) That's it."
-        let title = "\(config.routineType.rawValue) Skincare"
+        let body: String
+        if products.isEmpty {
+            body = config.routineType == .morning
+                ? "No skincare routine for this morning! Set up a routine in the app."
+                : "No skincare routine for tonight! Set up a routine in the app."
+        } else {
+            body = products.map(\.name).joined(separator: " > ") + "."
+        }
+        let title = "\(config.routineType.rawValue) Skincare Routine"
 
         let hour: Int
         let minute: Int

--- a/SkincareTracker/SkincareTrackerApp.swift
+++ b/SkincareTracker/SkincareTrackerApp.swift
@@ -2,6 +2,8 @@ import SwiftUI
 
 @main
 struct SkincareTrackerApp: App {
+    @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
+
     var body: some Scene {
         WindowGroup {
             ContentView()

--- a/SkincareTracker/Views/ContentView.swift
+++ b/SkincareTracker/Views/ContentView.swift
@@ -5,26 +5,50 @@
 
 import SwiftUI
 
+enum AppTab: Int {
+    case today, cycle, products, reminders
+}
+
 struct ContentView: View {
     @StateObject private var store = AppStore()
     @StateObject private var savedBanner = SavedBannerTrigger()
     @StateObject private var reminderService = ReminderService()
     @StateObject private var healthKitService = HealthKitService()
     @State private var showOnboarding = !OnboardingView.hasCompletedOnboarding
+    @State private var selectedTab: AppTab = .today
 
     var body: some View {
-        TabView {
+        TabView(selection: $selectedTab) {
             TodayView()
                 .tabItem { Label("Today", systemImage: "sun.max.fill") }
+                .tag(AppTab.today)
 
             CycleView()
                 .tabItem { Label("Cycle", systemImage: "arrow.2.circlepath") }
-            
+                .tag(AppTab.cycle)
+
             ProductsView()
                 .tabItem { Label("Products", systemImage: "drop.fill") }
-            
+                .tag(AppTab.products)
+
             RemindersView()
                 .tabItem { Label("Reminders", systemImage: "bell.fill") }
+                .tag(AppTab.reminders)
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .openTodayTab)) { _ in
+            selectedTab = .today
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .openCycleTab)) { _ in
+            selectedTab = .cycle
+        }
+        .onAppear {
+            if UserDefaults.standard.bool(forKey: openCycleTabKey) {
+                UserDefaults.standard.removeObject(forKey: openCycleTabKey)
+                selectedTab = .cycle
+            } else if UserDefaults.standard.bool(forKey: openTodayTabKey) {
+                UserDefaults.standard.removeObject(forKey: openTodayTabKey)
+                selectedTab = .today
+            }
         }
         .foregroundStyle(AppColors.textPrimary)
         .background(AppColors.background)

--- a/SkincareTracker/Views/Cycle/AddToCycleSheet.swift
+++ b/SkincareTracker/Views/Cycle/AddToCycleSheet.swift
@@ -222,11 +222,15 @@ private struct CreateProductAndAddToCycleSheet: View {
             ingredientErrorMessage = nameError
             return
         }
+        if store.hasDuplicateProduct(name: trimmedName, categoryId: selectedCategoryId) {
+            ingredientErrorMessage = "A product named \"\(trimmedName)\" in this category already exists."
+            return
+        }
 
         switch INCIIngredients.parseValidated(ingredientsText) {
         case .success(let ingredients):
             let product = Product(
-                name: name.trimmingCharacters(in: .whitespaces),
+                name: trimmedName,
                 ingredients: ingredients,
                 categoryId: selectedCategoryId
             )

--- a/SkincareTracker/Views/Cycle/AddToCycleSheet.swift
+++ b/SkincareTracker/Views/Cycle/AddToCycleSheet.swift
@@ -12,6 +12,9 @@ struct AddToCycleSheet: View {
     @EnvironmentObject var savedBanner: SavedBannerTrigger
     @Environment(\.dismiss) private var dismiss
 
+    /// When set, CycleView will pre-select this product after the sheet closes.
+    var onProductAdded: ((Product) -> Void)?
+
     @State private var searchText = ""
     @State private var showCreateProduct = false
 
@@ -30,6 +33,7 @@ struct AddToCycleSheet: View {
                         Button {
                             store.addProductToCycle(product)
                             savedBanner.show()
+                            onProductAdded?(product)
                             dismiss()
                         } label: {
                             HStack(spacing: 12) {
@@ -76,8 +80,9 @@ struct AddToCycleSheet: View {
             }
             .sheet(isPresented: $showCreateProduct) {
                 CreateProductAndAddToCycleSheet(
-                    onCreated: {
+                    onCreated: { product in
                         savedBanner.show()
+                        onProductAdded?(product)
                         dismiss()
                     },
                     onCancel: { showCreateProduct = false }
@@ -103,7 +108,7 @@ private struct CreateProductAndAddToCycleSheet: View {
     @State private var isScanning = false
     @State private var ingredientErrorMessage: String?
 
-    let onCreated: () -> Void
+    let onCreated: (Product) -> Void
     let onCancel: () -> Void
 
     var body: some View {
@@ -227,7 +232,7 @@ private struct CreateProductAndAddToCycleSheet: View {
             )
             store.addProduct(product)
             store.addProductToCycle(product)
-            onCreated()
+            onCreated(product)
             dismiss()
         case .failure(let error):
             ingredientErrorMessage = error.localizedDescription

--- a/SkincareTracker/Views/Cycle/CycleView.swift
+++ b/SkincareTracker/Views/Cycle/CycleView.swift
@@ -42,27 +42,6 @@ struct CycleView: View {
                 .environmentObject(store)
                 .environmentObject(savedBanner)
             }
-            .confirmationDialog("Remove from routine?", isPresented: Binding(
-                get: { productToRemove != nil },
-                set: { if !$0 { productToRemove = nil } }
-            )) {
-                Button("Remove", role: .destructive) {
-                    if let product = productToRemove {
-                        store.clearProductFromCycle(productId: product.id)
-                        if selectedProductId == product.id {
-                            selectedProductId = nil
-                        }
-                    }
-                    productToRemove = nil
-                }
-                Button("Cancel", role: .cancel) {
-                    productToRemove = nil
-                }
-            } message: {
-                if let product = productToRemove {
-                    Text("This will remove \"\(product.name)\" from your cycle.")
-                }
-            }
             .overlay(alignment: .bottom) {
                 if store.hasUnsavedCycleChanges {
                     Button {
@@ -164,11 +143,34 @@ struct CycleView: View {
                             isReorderMode: isProductsListEditing,
                             onSelect: {
                                 if !isProductsListEditing {
+                                    let isSelecting = selectedProductId != product.id
                                     selectedProductId = selectedProductId == product.id ? nil : product.id
+                                    if isSelecting {
+                                        expandedDayIndex = nil
+                                    }
                                 }
                             },
                             onDelete: { productToRemove = product }
                         )
+                        .confirmationDialog("Remove from routine?", isPresented: Binding(
+                            get: { productToRemove?.id == product.id },
+                            set: { if !$0 { productToRemove = nil } }
+                        )) {
+                            Button("Remove", role: .destructive) {
+                                if let p = productToRemove, p.id == product.id {
+                                    store.clearProductFromCycle(productId: p.id)
+                                    if selectedProductId == p.id {
+                                        selectedProductId = nil
+                                    }
+                                }
+                                productToRemove = nil
+                            }
+                            Button("Cancel", role: .cancel) {
+                                productToRemove = nil
+                            }
+                        } message: {
+                            Text("This will remove \"\(product.name)\" from your cycle.")
+                        }
                         .listRowSeparator(.hidden)
                         .listRowBackground(AppColors.surface)
                         .listRowInsets(EdgeInsets(top: 4, leading: 0, bottom: 4, trailing: 0))
@@ -188,9 +190,9 @@ struct CycleView: View {
                     .font(.subheadline)
                     .foregroundStyle(AppColors.accent)
                     .frame(maxWidth: .infinity)
-                    .padding(.vertical, 8)
-                    .background(AppColors.accentLight)
-                    .clipShape(RoundedRectangle(cornerRadius: 8))
+                    // .padding(.vertical, 8)
+                    // .background(AppColors.accentLight)
+                    // .clipShape(RoundedRectangle(cornerRadius: 8))
             }
         }
         .padding()
@@ -225,7 +227,6 @@ struct CycleView: View {
                                 if isToday {
                                     Text("Today")
                                         .font(.caption)
-                                        .fontWeight(.semibold)
                                         .foregroundStyle(AppColors.textSecondary)
                                         .padding(.vertical, 2)
                                         .clipShape(Capsule())
@@ -252,9 +253,6 @@ struct CycleView: View {
                                     isDayExpanded: isExpanded,
                                     productColor: { store.productColor(for: $0) }
                                 )
-                                if isExpanded {
-                                    routineDetailPanel(products: morningProducts, routineType: .morning)
-                                }
                             }
                             .frame(maxWidth: .infinity, alignment: .leading)
                             .contentShape(Rectangle())
@@ -277,9 +275,6 @@ struct CycleView: View {
                                     isDayExpanded: isExpanded,
                                     productColor: { store.productColor(for: $0) }
                                 )
-                                if isExpanded {
-                                    routineDetailPanel(products: nightProducts, routineType: .night)
-                                }
                             }
                             .frame(maxWidth: .infinity, alignment: .leading)
                             .contentShape(Rectangle())
@@ -291,16 +286,24 @@ struct CycleView: View {
                                 }
                             }
                         }
-                        .padding(isToday ? 8 : 0)
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 12)
-                                .stroke(isToday ? AppColors.accent : Color.clear, lineWidth: 2)
-                        )
-                        .clipShape(RoundedRectangle(cornerRadius: 12))
-                        .contextMenu {
-                            Button("Set as today") {
-                                store.setTodayToCycleDay(dayIndex)
+                        
+                        if isExpanded {
+                            VStack(alignment: .leading, spacing: 8) {
+                                routineDetailPanel(products: morningProducts, routineType: .morning)
+                                routineDetailPanel( products: nightProducts, routineType: .night)
                             }
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                        }
+                    }
+                    .padding(isToday ? 8 : 0)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 12)
+                            .stroke(isToday ? AppColors.accentLight : Color.clear, lineWidth: 2)
+                    )
+                    .clipShape(RoundedRectangle(cornerRadius: 12))
+                    .contextMenu {
+                        Button("Set as today") {
+                            store.setTodayToCycleDay(dayIndex)
                         }
                     }
                 }
@@ -332,6 +335,7 @@ struct CycleView: View {
                 }
             }
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
         .padding()
         .background(AppColors.surface)
         .clipShape(RoundedRectangle(cornerRadius: 16))
@@ -367,12 +371,19 @@ struct CycleView: View {
     @ViewBuilder
     private func routineDetailPanel(products: [Product], routineType: RoutineType) -> some View {
         VStack(alignment: .leading, spacing: 8) {
+            Text(routineType == .morning ? "Morning routine" : "Night routine")
+                    .font(.caption)
+                    .foregroundStyle(AppColors.textSecondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal, 12)
+                    .padding(.top, 6)
             if products.isEmpty {
                 Text("No products assigned")
                     .font(.caption)
                     .foregroundStyle(AppColors.textTertiary)
                     .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(12)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 6)
             } else {
                 VStack(alignment: .leading, spacing: 8) {
                     ForEach(products) { product in
@@ -390,7 +401,8 @@ struct CycleView: View {
                     }
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(12)
+                .padding(.horizontal, 12)
+                .padding(.bottom, 6)
             }
         }
         .background(AppColors.rowBackground)
@@ -412,12 +424,6 @@ private struct ProductRow: View {
     var body: some View {
         Button(action: onSelect) {
             HStack(spacing: 12) {
-                if isReorderMode {
-                    Image(systemName: "line.3.horizontal")
-                        .font(.body)
-                        .foregroundStyle(AppColors.textSecondary)
-                }
-                
                 if let color {
                     Circle()
                         .fill(color)
@@ -446,7 +452,7 @@ private struct ProductRow: View {
             .background(isSelected ? AppColors.rowSelected : AppColors.rowBackground)
             .overlay(
                 RoundedRectangle(cornerRadius: 12)
-                    .strokeBorder(isSelected && !isReorderMode ? AppColors.accent : Color.clear, lineWidth: 2)
+                    .strokeBorder(isSelected && !isReorderMode ? AppColors.accent : Color.clear, lineWidth: 1)
             )
             .clipShape(RoundedRectangle(cornerRadius: 12))
         }
@@ -476,51 +482,57 @@ private struct CycleSlotCell: View {
     }
     
     var body: some View {
-        VStack(spacing: 8) {
+        VStack(alignment: .center, spacing: 6) {
             Image(systemName: routineType == .morning ? "sun.max.fill" : "moon.fill")
                 .font(.caption)
                 .foregroundStyle(routineType == .morning ? AppColors.morningAccent : AppColors.nightAccent)
                 .frame(maxWidth: .infinity, alignment: .trailing)
                 .padding(.horizontal, 12)
+                .padding(.top, 8)
 
             Text(routineType == .morning ? "Morning" : "Night")
                 .font(.caption2)
                 .fontWeight(.medium)
                 .foregroundStyle(AppColors.textSecondary)
             
-            if products.isEmpty {
-                Text("Tap to add")
-                    .font(.caption2)
-                    .foregroundStyle(AppColors.textTertiary)
-            } else {
-                Text("\(products.count) \(products.count == 1 ? "product" : "products")")
-                    .font(.caption)
-                    .fontWeight(.semibold)
-                    .foregroundStyle(AppColors.textPrimary)
+            VStack(alignment: .center, spacing: 6) {
+                if products.isEmpty {
+                    Text("Tap to add")
+                        .font(.caption2)
+                        .foregroundStyle(AppColors.textTertiary)
+                } else {
+                    Text("\(products.count) \(products.count == 1 ? "product" : "products")")
+                        .font(.caption2)
+                        .fontWeight(.semibold)
+                        .foregroundStyle(AppColors.textPrimary)
+                }
+
+                HStack(spacing: 4) {
+                    if products.isEmpty {
+                        Color.clear.frame(width: 6, height: 6)
+                    } else {
+                        ForEach(products.prefix(5)) { product in
+                            if let color = productColor(product) {
+                                Circle()
+                                    .fill(color)
+                                    .frame(width: 6, height: 6)
+                            }
+                        }
+                        if products.count > 5 {
+                            Text("...")
+                                .font(.caption2)
+                                .foregroundStyle(AppColors.textTertiary)
+                        }
+                    }
+                }
             }
+            .frame(maxWidth: .infinity, alignment: .center)
+            .padding(.horizontal, 12)
+            .padding(.bottom, 8)
         }
         .frame(maxWidth: .infinity)
         .frame(height: 88)
         .background(emptyBackground)
-        .overlay(alignment: .bottom) {
-            if !products.isEmpty {
-                HStack(spacing: 4) {
-                    ForEach(products.prefix(5)) { product in
-                        if let color = productColor(product) {
-                            Circle()
-                                .fill(color)
-                                .frame(width: 6, height: 6)
-                        }
-                    }
-                    if products.count > 5 {
-                        Text("...")
-                            .font(.caption2)
-                            .foregroundStyle(AppColors.textTertiary)
-                    }
-                }
-                .padding(.bottom, 6)
-            }
-        }
         .overlay(
             RoundedRectangle(cornerRadius: 12)
                 .strokeBorder(isSelected ? AppColors.accent : (isDayExpanded ? (routineType == .morning ? AppColors.morningAccent : AppColors.nightAccent) : Color.clear), lineWidth: 2)

--- a/SkincareTracker/Views/Cycle/CycleView.swift
+++ b/SkincareTracker/Views/Cycle/CycleView.swift
@@ -36,9 +36,11 @@ struct CycleView: View {
             .background(AppColors.background)
             .navigationTitle("Skincare Cycle")
             .sheet(isPresented: $showAddProduct) {
-                AddToCycleSheet()
-                    .environmentObject(store)
-                    .environmentObject(savedBanner)
+                AddToCycleSheet(onProductAdded: { product in
+                    selectedProductId = product.id
+                })
+                .environmentObject(store)
+                .environmentObject(savedBanner)
             }
             .confirmationDialog("Remove from routine?", isPresented: Binding(
                 get: { productToRemove != nil },
@@ -134,6 +136,7 @@ struct CycleView: View {
                 .buttonStyle(.bordered)
                 .tint(isProductsListEditing ? AppColors.rowBackground : AppColors.accentLight)
                 Button {
+                    expandedDayIndex = nil
                     showAddProduct = true
                 } label: {
                     Label("Add", systemImage: "plus")
@@ -167,7 +170,7 @@ struct CycleView: View {
                             onDelete: { productToRemove = product }
                         )
                         .listRowSeparator(.hidden)
-                        .listRowBackground(Color.clear)
+                        .listRowBackground(AppColors.surface)
                         .listRowInsets(EdgeInsets(top: 4, leading: 0, bottom: 4, trailing: 0))
                     }
                     .onMove { store.moveProductInCycleOrder(from: $0, to: $1) }
@@ -177,6 +180,7 @@ struct CycleView: View {
                 .scrollContentBackground(.hidden)
                 .scrollDisabled(true)
                 .frame(minHeight: CGFloat(store.productsInCycleOrdered.count) * 52)
+                .padding(.bottom, 8)
             }
             
             if selectedProductId != nil {
@@ -313,7 +317,7 @@ struct CycleView: View {
                 .font(.subheadline.weight(.medium))
                 .foregroundStyle(AppColors.textSecondary)
 
-            FlowLayout(spacing: 12) {
+            VStack(alignment: .leading, spacing: 6) {
                 ForEach(store.productsInCycleOrdered) { product in
                     HStack(spacing: 6) {
                         if let color = store.productColor(for: product) {
@@ -370,7 +374,7 @@ struct CycleView: View {
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(12)
             } else {
-                VStack(alignment: .leading, spacing: 6) {
+                VStack(alignment: .leading, spacing: 8) {
                     ForEach(products) { product in
                         HStack(spacing: 8) {
                             if let color = store.productColor(for: product) {
@@ -382,6 +386,7 @@ struct CycleView: View {
                                 .font(.caption)
                                 .foregroundStyle(AppColors.textPrimary)
                         }
+                        .frame(maxWidth: .infinity, alignment: .leading)
                     }
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -441,7 +446,7 @@ private struct ProductRow: View {
             .background(isSelected ? AppColors.rowSelected : AppColors.rowBackground)
             .overlay(
                 RoundedRectangle(cornerRadius: 12)
-                    .strokeBorder(isSelected ? AppColors.accent : Color.clear, lineWidth: 2)
+                    .strokeBorder(isSelected && !isReorderMode ? AppColors.accent : Color.clear, lineWidth: 2)
             )
             .clipShape(RoundedRectangle(cornerRadius: 12))
         }
@@ -521,54 +526,6 @@ private struct CycleSlotCell: View {
                 .strokeBorder(isSelected ? AppColors.accent : (isDayExpanded ? (routineType == .morning ? AppColors.morningAccent : AppColors.nightAccent) : Color.clear), lineWidth: 2)
         )
         .clipShape(RoundedRectangle(cornerRadius: 12))
-    }
-}
-
-// MARK: - Flow Layout
-
-private struct FlowLayout: Layout {
-    var spacing: CGFloat = 8
-    
-    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
-        let result = arrange(subviews: subviews, proposal: proposal)
-        return result.size
-    }
-    
-    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
-        let result = arrange(subviews: subviews, proposal: proposal)
-        for (index, subview) in subviews.enumerated() {
-            let point = CGPoint(
-                x: bounds.minX + result.positions[index].x,
-                y: bounds.minY + result.positions[index].y
-            )
-            subview.place(at: point, anchor: .topLeading, proposal: .unspecified)
-        }
-    }
-    
-    private func arrange(subviews: Subviews, proposal: ProposedViewSize) -> (size: CGSize, positions: [CGPoint]) {
-        let proposedWidth = proposal.width ?? .infinity
-        let maxWidth: CGFloat = proposedWidth.isFinite ? proposedWidth : 400
-        var positions: [CGPoint] = []
-        var x: CGFloat = 0
-        var y: CGFloat = 0
-        var rowHeight: CGFloat = 0
-        
-        for subview in subviews {
-            let size = subview.sizeThatFits(.unspecified)
-            let w = size.width.isFinite ? size.width : 0
-            let h = size.height.isFinite ? size.height : 0
-            if x + w > maxWidth && x > 0 {
-                x = 0
-                y += rowHeight + spacing
-                rowHeight = 0
-            }
-            positions.append(CGPoint(x: x, y: y))
-            rowHeight = max(rowHeight, h)
-            x += w + spacing
-        }
-        
-        let totalHeight = (y + rowHeight).isFinite ? (y + rowHeight) : 0
-        return (CGSize(width: maxWidth, height: totalHeight), positions)
     }
 }
 

--- a/SkincareTracker/Views/Onboarding/OnboardingView.swift
+++ b/SkincareTracker/Views/Onboarding/OnboardingView.swift
@@ -36,6 +36,11 @@ struct OnboardingView: View {
         }
         .background(AppColors.background)
         .interactiveDismissDisabled()
+        .onAppear {
+            if HealthKitService.isAvailable {
+                Task { await requestHealthAccess() }
+            }
+        }
     }
 
     private var header: some View {

--- a/SkincareTracker/Views/Products/AddProductView.swift
+++ b/SkincareTracker/Views/Products/AddProductView.swift
@@ -124,15 +124,20 @@ struct AddProductView: View {
     }
 
     private func saveProduct() {
-        if let nameError = InputSanitizer.validateProductName(name) {
+        let trimmedName = name.trimmingCharacters(in: .whitespaces)
+        if let nameError = InputSanitizer.validateProductName(trimmedName) {
             ingredientErrorMessage = nameError
+            return
+        }
+        if store.hasDuplicateProduct(name: trimmedName, categoryId: selectedCategoryId) {
+            ingredientErrorMessage = "A product named \"\(trimmedName)\" in this category already exists."
             return
         }
 
         switch INCIIngredients.parseValidated(ingredientsText) {
         case .success(let ingredients):
             let product = Product(
-                name: name,
+                name: trimmedName,
                 ingredients: ingredients,
                 categoryId: selectedCategoryId
             )

--- a/SkincareTracker/Views/Products/EditProductView.swift
+++ b/SkincareTracker/Views/Products/EditProductView.swift
@@ -132,14 +132,19 @@ struct EditProductView: View {
     }
 
     private func saveChanges() {
-        if let nameError = InputSanitizer.validateProductName(name) {
+        let trimmedName = name.trimmingCharacters(in: .whitespaces)
+        if let nameError = InputSanitizer.validateProductName(trimmedName) {
             ingredientErrorMessage = nameError
+            return
+        }
+        if store.hasDuplicateProduct(name: trimmedName, categoryId: selectedCategoryId, excludingProductId: product.id) {
+            ingredientErrorMessage = "A product named \"\(trimmedName)\" in this category already exists."
             return
         }
 
         switch INCIIngredients.parseValidated(ingredientsText) {
         case .success(let ingredients):
-            store.updateProduct(productId: product.id, name: name, ingredients: ingredients, categoryId: selectedCategoryId)
+            store.updateProduct(productId: product.id, name: trimmedName, ingredients: ingredients, categoryId: selectedCategoryId)
             savedBanner.show()
             dismiss()
         case .failure(let error):

--- a/SkincareTracker/Views/Products/ProductsView.swift
+++ b/SkincareTracker/Views/Products/ProductsView.swift
@@ -13,14 +13,14 @@ struct ProductsView: View {
     var body: some View {
         NavigationStack {
             List {
-                ForEach(store.sortedProducts) { product in
+                ForEach(store.productsForListView) { product in
                     NavigationLink(destination: ProductDetailView(product: product)) {
                         ProductRowView(product: product)
                     }
                     .listRowBackground(AppColors.rowBackground)
                 }
                 .onDelete { offsets in
-                    store.deleteProducts(at: offsets, from: store.sortedProducts)
+                    store.deleteProducts(at: offsets, from: store.productsForListView)
                 }
             }
             .scrollContentBackground(.hidden)

--- a/SkincareTracker/Views/Reminders/RemindersView.swift
+++ b/SkincareTracker/Views/Reminders/RemindersView.swift
@@ -140,10 +140,10 @@ struct ReminderRowView: View {
             Text(config.routineType.rawValue + " Routine")
                 .foregroundStyle(AppColors.sectionHeader)
         } footer: {
-            if useHealthWakeTime && isMorningRoutine {
+            if healthKitAvailable && useHealthWakeTime && isMorningRoutine {
                 Text("Reminder fires when your Health sleep routine ends (when you wake up).")
                     .foregroundStyle(AppColors.textSecondary)
-            } else if useHealthBedtime && isNightRoutine {
+            } else if healthKitAvailable && useHealthBedtime && isNightRoutine {
                 Text("Reminder fires 1 hour before your typical bedtime from the Health app.")
                     .foregroundStyle(AppColors.textSecondary)
             } else {
@@ -178,14 +178,33 @@ struct TimePickerSheet: View {
     @Binding var minute: Int
     let onDismiss: () -> Void
 
+    private var date: Binding<Date> {
+        Binding(
+            get: {
+                var components = DateComponents()
+                components.hour = hour
+                components.minute = minute
+                return Calendar.current.date(from: components) ?? Date()
+            },
+            set: { newDate in
+                let components = Calendar.current.dateComponents([.hour, .minute], from: newDate)
+                hour = components.hour ?? 0
+                minute = components.minute ?? 0
+            }
+        )
+    }
+
     var body: some View {
         NavigationStack {
             Form {
                 Section {
-                    Stepper("Hour: \(hour)", value: $hour, in: 0...23)
-                    Stepper("Minute: \(minute)", value: $minute, in: 0...59)
+                    DatePicker("Time", selection: date, displayedComponents: .hourAndMinute)
+                        .labelsHidden()
+                        .listRowBackground(AppColors.rowBackground)
                 }
             }
+            .scrollContentBackground(.hidden)
+            .background(AppColors.background)
             .navigationTitle("Reminder Time")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {

--- a/SkincareTracker/Views/Reminders/RemindersView.swift
+++ b/SkincareTracker/Views/Reminders/RemindersView.swift
@@ -67,7 +67,22 @@ struct ReminderRowView: View {
     @State private var minute: Int
     @State private var useHealthWakeTime: Bool
     @State private var useHealthBedtime: Bool
-    @State private var showTimePicker = false
+
+    private var timeDate: Binding<Date> {
+        Binding(
+            get: {
+                var components = DateComponents()
+                components.hour = hour
+                components.minute = minute
+                return Calendar.current.date(from: components) ?? Date()
+            },
+            set: { newDate in
+                let components = Calendar.current.dateComponents([.hour, .minute], from: newDate)
+                hour = components.hour ?? 0
+                minute = components.minute ?? 0
+            }
+        )
+    }
 
     init(config: ReminderConfig, healthKitAvailable: Bool, onSave: @escaping (ReminderConfig) -> Void) {
         self.config = config
@@ -122,18 +137,14 @@ struct ReminderRowView: View {
                 }
                 .listRowBackground(AppColors.rowBackground)
             } else {
-                Button {
-                    showTimePicker = true
-                } label: {
-                    HStack {
-                        Text("Time")
-                            .foregroundStyle(AppColors.textPrimary)
-                        Spacer()
-                        Text(String(format: "%d:%02d", hour, minute))
-                            .foregroundStyle(AppColors.textSecondary)
-                    }
+                HStack {
+                    Text("Time")
+                        .foregroundStyle(AppColors.textPrimary)
+                    Spacer()
+                    DatePicker("", selection: timeDate, displayedComponents: .hourAndMinute)
+                        .labelsHidden()
+                        .disabled(!isEnabled)
                 }
-                .disabled(!isEnabled)
                 .listRowBackground(AppColors.rowBackground)
             }
         } header: {
@@ -153,13 +164,6 @@ struct ReminderRowView: View {
         }
         .onChange(of: hour) { _, _ in saveConfig() }
         .onChange(of: minute) { _, _ in saveConfig() }
-        .sheet(isPresented: $showTimePicker) {
-            TimePickerSheet(
-                hour: $hour,
-                minute: $minute,
-                onDismiss: { showTimePicker = false }
-            )
-        }
     }
 
     private func saveConfig() {
@@ -170,51 +174,6 @@ struct ReminderRowView: View {
         newConfig.useHealthWakeTime = useHealthWakeTime
         newConfig.useHealthBedtime = useHealthBedtime
         onSave(newConfig)
-    }
-}
-
-struct TimePickerSheet: View {
-    @Binding var hour: Int
-    @Binding var minute: Int
-    let onDismiss: () -> Void
-
-    private var date: Binding<Date> {
-        Binding(
-            get: {
-                var components = DateComponents()
-                components.hour = hour
-                components.minute = minute
-                return Calendar.current.date(from: components) ?? Date()
-            },
-            set: { newDate in
-                let components = Calendar.current.dateComponents([.hour, .minute], from: newDate)
-                hour = components.hour ?? 0
-                minute = components.minute ?? 0
-            }
-        )
-    }
-
-    var body: some View {
-        NavigationStack {
-            Form {
-                Section {
-                    DatePicker("Time", selection: date, displayedComponents: .hourAndMinute)
-                        .labelsHidden()
-                        .listRowBackground(AppColors.rowBackground)
-                }
-            }
-            .scrollContentBackground(.hidden)
-            .background(AppColors.background)
-            .navigationTitle("Reminder Time")
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .confirmationAction) {
-                    Button("Done") {
-                        onDismiss()
-                    }
-                }
-            }
-        }
     }
 }
 

--- a/SkincareTracker/Views/Today/TodayView.swift
+++ b/SkincareTracker/Views/Today/TodayView.swift
@@ -10,7 +10,6 @@ import SwiftUI
 struct TodayView: View {
     @EnvironmentObject var store: AppStore
     @EnvironmentObject var savedBanner: SavedBannerTrigger
-    @State private var showPutOffPrompt: PutOffPromptItem?
 
     private let calendar = Calendar.current
 
@@ -48,15 +47,6 @@ struct TodayView: View {
             }
             .background(AppColors.background)
             .navigationTitle("Today's Routine")
-            .sheet(item: $showPutOffPrompt) { prompt in
-                PutOffSheetView(
-                    item: prompt.scheduleItem,
-                    routineType: prompt.routineType,
-                    onDismiss: { showPutOffPrompt = nil }
-                )
-                .environmentObject(store)
-                .environmentObject(savedBanner)
-            }
         }
     }
 
@@ -114,16 +104,14 @@ struct TodayView: View {
                 title: "Morning routine",
                 icon: "sun.max.fill",
                 products: morningProducts,
-                iconGradient: [AppColors.morning, Color(red: 255/255, green: 235/255, blue: 150/255)],
-                putOffRoutineType: .morning
+                iconGradient: [AppColors.morning, Color(red: 255/255, green: 235/255, blue: 150/255)]
             )
 
             routineCard(
                 title: "Night routine",
                 icon: "moon.fill",
                 products: nightProducts,
-                iconGradient: [AppColors.night, Color(red: 130/255, green: 170/255, blue: 230/255)],
-                putOffRoutineType: .night
+                iconGradient: [AppColors.night, Color(red: 130/255, green: 170/255, blue: 230/255)]
             )
         }
     }
@@ -132,8 +120,7 @@ struct TodayView: View {
         title: String,
         icon: String,
         products: [Product],
-        iconGradient: [Color],
-        putOffRoutineType: RoutineType
+        iconGradient: [Color]
     ) -> some View {
         VStack(alignment: .leading, spacing: 12) {
             HStack(spacing: 12) {
@@ -162,22 +149,15 @@ struct TodayView: View {
                     .foregroundStyle(AppColors.textTertiary)
             } else {
                 ForEach(products) { product in
-                    if let item = scheduleItem(for: product, routineType: putOffRoutineType) {
-                        TodayProductRow(
-                            item: item,
-                            onPutOff: { showPutOffPrompt = PutOffPromptItem(scheduleItem: item, routineType: putOffRoutineType) }
-                        )
-                    } else {
-                        HStack(spacing: 12) {
-                            if let color = store.productColor(for: product) {
-                                Circle()
-                                    .fill(color)
-                                    .frame(width: 8, height: 8)
-                            }
-                            Text(product.name)
-                                .font(.body)
-                                .foregroundStyle(AppColors.textPrimary)
+                    HStack(spacing: 12) {
+                        if let color = store.productColor(for: product) {
+                            Circle()
+                                .fill(color)
+                                .frame(width: 8, height: 8)
                         }
+                        Text(product.name)
+                            .font(.body)
+                            .foregroundStyle(AppColors.textPrimary)
                     }
                 }
             }
@@ -186,14 +166,6 @@ struct TodayView: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(AppColors.surface)
         .clipShape(RoundedRectangle(cornerRadius: 16))
-    }
-
-    private func scheduleItem(for product: Product, routineType: RoutineType) -> ScheduleItem? {
-        store.scheduleItems.first { item in
-            item.productId == product.id &&
-            calendar.isDate(item.date, inSameDayAs: todayStart) &&
-            item.routineType == routineType
-        }
     }
 
     @ViewBuilder
@@ -213,53 +185,6 @@ struct TodayView: View {
             .background(AppColors.accentLight)
             .clipShape(RoundedRectangle(cornerRadius: 16))
         }
-    }
-}
-
-// MARK: - Supporting Types
-
-struct PutOffPromptItem: Identifiable {
-    let id = UUID()
-    let scheduleItem: ScheduleItem
-    let routineType: RoutineType
-}
-
-struct TodayProductRow: View {
-    @EnvironmentObject var store: AppStore
-    let item: ScheduleItem
-    let onPutOff: () -> Void
-
-    private var product: Product? {
-        item.product ?? store.product(by: item.productId)
-    }
-
-    var body: some View {
-        HStack {
-            HStack(spacing: 12) {
-                if let product, let color = store.productColor(for: product) {
-                    Circle()
-                        .fill(color)
-                        .frame(width: 8, height: 8)
-                }
-                Text(item.productName)
-                    .font(.body)
-                    .foregroundStyle(AppColors.textPrimary)
-            }
-            Spacer()
-            Button {
-                onPutOff()
-            } label: {
-                Text("Put Off")
-                    .font(.caption)
-                    .padding(.horizontal, 8)
-                    .padding(.vertical, 4)
-                    .background(AppColors.putOffLight)
-                    .foregroundStyle(AppColors.putOff)
-                    .clipShape(Capsule())
-            }
-            .buttonStyle(.plain)
-        }
-        .padding(.vertical, 4)
     }
 }
 

--- a/SkincareTrackerTests/IngredientTests.swift
+++ b/SkincareTrackerTests/IngredientTests.swift
@@ -103,10 +103,10 @@ final class INCIIngredientsTests: XCTestCase {
 
     // MARK: - normalizeForParsing
 
-    func testNormalizeForParsing_replacesNewlinesWithCommas() throws {
-        let input = "Water\nGlycerin\nNiacinamide"
+    func testNormalizeForParsing_newlineWithoutComma_isLineContinuation() throws {
+        let input = "sodium\nmethyl cocoyl taurate, Glycerin"
         let result = INCIIngredients.normalizeForParsing(input)
-        XCTAssertEqual(result, "Water, Glycerin, Niacinamide")
+        XCTAssertEqual(result, "sodium methyl cocoyl taurate, Glycerin")
     }
 
     func testNormalizeForParsing_replacesSemicolonsWithCommas() throws {
@@ -116,11 +116,34 @@ final class INCIIngredientsTests: XCTestCase {
     }
 
     func testNormalizeForParsing_parseAfterNormalize_producesCorrectIngredients() throws {
-        let ocrStyleText = "Aqua\nGlycerin\nNiacinamide\nHyaluronic Acid"
+        let ocrStyleText = "Aqua,\nGlycerin,\nNiacinamide,\nHyaluronic Acid"
         let normalized = INCIIngredients.normalizeForParsing(ocrStyleText)
         let ingredients = INCIIngredients.parse(normalized)
         let names = ingredients.map(\.name)
         XCTAssertEqual(names, ["Aqua", "Glycerin", "Niacinamide", "Hyaluronic Acid"])
+    }
+
+    func testNormalizeForParsing_stripsIngredientsHeader() throws {
+        let ocrWithHeader = "INGREDIENTS\nAqua, Glycerin, Niacinamide"
+        let result = INCIIngredients.normalizeForParsing(ocrWithHeader)
+        XCTAssertFalse(result.lowercased().contains("ingredients"))
+        let ingredients = INCIIngredients.parse(result)
+        XCTAssertEqual(ingredients.map(\.name), ["Aqua", "Glycerin", "Niacinamide"])
+    }
+
+    func testNormalizeForParsing_lineContinuation_sodiumMethyl() throws {
+        // No comma before newline → line wrap
+        let input = "Aqua, Glycerin, sodium\nmethyl cocoyl taurate, Niacinamide"
+        let result = INCIIngredients.normalizeForParsing(input)
+        XCTAssertTrue(result.contains("sodium methyl cocoyl taurate"), "Expected 'sodium methyl cocoyl taurate' as one ingredient")
+    }
+
+    func testNormalizeForParsing_commaAtEOL_noDoubleComma() throws {
+        let input = "Aqua, niacinamide,\nGlycerin"
+        let result = INCIIngredients.normalizeForParsing(input)
+        XCTAssertFalse(result.contains(",,"), "Should not produce double comma")
+        let ingredients = INCIIngredients.parse(result)
+        XCTAssertEqual(ingredients.map(\.name), ["Aqua", "Niacinamide", "Glycerin"])
     }
 
     func testParse_waterAliases() throws {

--- a/SkincareTrackerTests/ReminderServiceTests.swift
+++ b/SkincareTrackerTests/ReminderServiceTests.swift
@@ -22,8 +22,8 @@ final class ReminderServiceTests: XCTestCase {
             healthBedtime: nil
         )
 
-        XCTAssertEqual(params.body, "Good morning, Here is your morning skincare routine: Cleanser, Serum. That's it.")
-        XCTAssertEqual(params.title, "Morning Skincare")
+        XCTAssertEqual(params.body, "Cleanser > Serum.")
+        XCTAssertEqual(params.title, "Morning Skincare Routine")
         XCTAssertEqual(params.hour, 8)
         XCTAssertEqual(params.minute, 30)
         XCTAssertEqual(params.identifier, "morning")
@@ -40,8 +40,8 @@ final class ReminderServiceTests: XCTestCase {
             healthBedtime: nil
         )
 
-        XCTAssertEqual(params.body, "Good morning, Here is your morning skincare routine: Moisturizer. That's it.")
-        XCTAssertEqual(params.title, "Morning Skincare")
+        XCTAssertEqual(params.body, "Moisturizer.")
+        XCTAssertEqual(params.title, "Morning Skincare Routine")
         XCTAssertEqual(params.hour, 7)
         XCTAssertEqual(params.minute, 0)
     }
@@ -56,7 +56,7 @@ final class ReminderServiceTests: XCTestCase {
             healthBedtime: nil
         )
 
-        XCTAssertEqual(params.body, "Good morning, Here is your morning skincare routine. That's it.")
+        XCTAssertEqual(params.body, "No skincare routine for this morning! Set up a routine in the app.")
         XCTAssertEqual(params.hour, 8)
         XCTAssertEqual(params.minute, 0)
     }
@@ -72,8 +72,8 @@ final class ReminderServiceTests: XCTestCase {
             healthBedtime: nil
         )
 
-        XCTAssertEqual(params.body, "Good night, Here is your night skincare routine: Cleanser, Retinol. That's it.")
-        XCTAssertEqual(params.title, "Night Skincare")
+        XCTAssertEqual(params.body, "Cleanser > Retinol.")
+        XCTAssertEqual(params.title, "Night Skincare Routine")
         XCTAssertEqual(params.hour, 21)
         XCTAssertEqual(params.minute, 0)
         XCTAssertEqual(params.identifier, "night")
@@ -98,7 +98,7 @@ final class ReminderServiceTests: XCTestCase {
             healthBedtime: (hour: 22, minute: 30)
         )
 
-        XCTAssertEqual(params.body, "Good night, Here is your night skincare routine. That's it.")
+        XCTAssertEqual(params.body, "No skincare routine for tonight! Set up a routine in the app.")
         XCTAssertEqual(params.hour, 21)
         XCTAssertEqual(params.minute, 30, "22:30 - 1hr = 21:30")
     }


### PR DESCRIPTION
address these:

- [x] When you add a product in cycle view, have it pre selected so that users can click on the routines right away without having to select it first
- [x] The last product in the list of products in CycleView occasionally gets cut off so that only the top half is visible.
- [x] when you select a product to add to the cycle, close any open routine details
- [x] Get rid of put off button

- [x] Using drag and drop ruins the legend - should be one product per line
- [x] time picker for the reminders is difficult to use. use a standard time picker that uses the time format of the users device e.g. 24 hour time or AM/PM depending on their settings. 

- [x] When reordering products in the products list in cycleview, when you hold down on a product to move it, an ugly black border appears around the product.

- [x] Products list in product view should show the products currently used in the cycle first, and all products should be in alphabetical order.
- [x] Ui for detailed routine view in cycle view can be improved - have routines vertically stacked so that product names don’t have to wrap
- [x] users should not be able to add products with identical product names and categories.
- [x] another page shouldn't pop up just to change the time for the reminders. they should remain on the reminders page and view the time picker where the time they are picking for is.
- [x] when deleing a product from the routine, the confirmation message shows at the top of the screen.
- [x] when there are 6+ products, the dots at the bottom of the routine squares overlap with the “x products” text and are a bit higher than the others.
- [x] when user clicks on the notification sent when they have no routine, send them to the cycleview to get started

as well as some small ui improvements