### PR TITLE
Fix/healthkit legend

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,13 @@ open SkincareTracker.xcodeproj
 3. Set deployment target to iOS 17
 4. Add the Info.plist entries for notifications and calendar usage
 
+## HealthKit (sleep-based reminders)
+
+- **Where to see your app:** Third-party apps are **not** listed under *Settings → Privacy & Security → Health* the way you might expect. After you allow access, manage them in the **Health** app: tap your **profile picture** (top right) → **Apps** (wording can vary slightly by iOS version).
+- **Xcode:** Open the **SkincareTracker** target → **Signing & Capabilities** → add **HealthKit** if it is missing (the project already includes `SkincareTracker.entitlements` with `com.apple.developer.healthkit`).
+- **Apple Developer:** The App ID for your bundle identifier must have the **HealthKit** capability enabled, and your provisioning profile must include it (Xcode usually fixes this when you add the capability).
+- Until the system successfully runs a Health permission request for your build, your app may not appear under Health → Apps.
+
 ## Features
 
 - **Products** – Add skincare products with names and ingredients

--- a/SkincareTracker.xcodeproj/project.pbxproj
+++ b/SkincareTracker.xcodeproj/project.pbxproj
@@ -11,43 +11,56 @@
 		3E47B9FA2CC3E3645844DBA3 /* PutOffSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55F6757401F5E0B0E1BDED0D /* PutOffSheetView.swift */; };
 		4465B7916BC3337481DF9A85 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E1901467DAE88558CF03020 /* ContentView.swift */; };
 		4AFCCDF488578343A9EA87DF /* CycleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2D6154E783D16AD56331501 /* CycleView.swift */; };
-		AABBCCDDEEFF112233445566 /* AddToCycleSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 112233445566778899AABBCC /* AddToCycleSheet.swift */; };
 		50D4C32BA908C4E6F7C85868 /* ReminderConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = A78EAA39EB47AD86BE7867A7 /* ReminderConfig.swift */; };
 		52EEAAF9DF6E84DFD152C350 /* SkincareTrackerApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = A73038CA622F55888E53CEE9 /* SkincareTrackerApp.swift */; };
-		A1P2P3D4E5L6E7G8A9T0E2 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1P2P3D4E5L6E7G8A9T0E1 /* AppDelegate.swift */; };
 		60A4FCE1C61FBBBBAC4B09DE /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 72076678EDAFFA62005D8DC9 /* Assets.xcassets */; };
 		713D831DA5728E9DEB40202B /* ProductsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C4550BBFC4C13454DC5FCA9 /* ProductsView.swift */; };
 		75EE04963A079A11531017EE /* RemindersView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 769A7F0776C822F50B8C737B /* RemindersView.swift */; };
 		7D6AA3C9C1AE9B0EDECBBBB1 /* AppStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 338F7255BE9852B37C01C671 /* AppStore.swift */; };
 		8D37D5C205779F9D50BDDCF6 /* SavedBannerTrigger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19F07FC03C73AE8B54505FF3 /* SavedBannerTrigger.swift */; };
 		9534495B6281DE51194DCBFB /* Product.swift in Sources */ = {isa = PBXBuildFile; fileRef = F352F62F49CD44AF927C9615 /* Product.swift */; };
-		I1N2C3I4I5N6G7R8E9D0E1 /* INCIIngredients.swift in Sources */ = {isa = PBXBuildFile; fileRef = I1N2C3I4I5N6G7R8E9D0E0 /* INCIIngredients.swift */; };
-		I5N6P7U8T9S0A1N2I3T4I6 /* InputSanitizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = I5N6P7U8T9S0A1N2I3T4I5 /* InputSanitizer.swift */; };
-		P1C2A3T4E5G6O7R8Y9ABCDEF /* ProductCategory.swift in Sources */ = {isa = PBXBuildFile; fileRef = P1C2A3T4E5G6O7R8Y9ABCDE0 /* ProductCategory.swift */; };
 		985D0CAD9A464C6363E59C08 /* ScheduleItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = E043360F1DD5EC668C8E397D /* ScheduleItem.swift */; };
+		A1P2P3D4E5L6E7G8A9T0E2 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1P2P3D4E5L6E7G8A9T0E1 /* AppDelegate.swift */; };
 		A58769D6AF2311B1B09CEAB8 /* AddProductView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1208C60B06EF135F46C71500 /* AddProductView.swift */; };
+		AABBCCDDEEFF112233445566 /* AddToCycleSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 112233445566778899AABBCC /* AddToCycleSheet.swift */; };
+		AP1S2T3A4T5E6P7E8R9S001 /* AppStatePersistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = AP1S2T3A4T5E6P7E8R9S002 /* AppStatePersistence.swift */; };
+		AP1S2T3A4T5E6P7E8R9S003 /* AppStatePersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AP1S2T3A4T5E6P7E8R9S004 /* AppStatePersistenceTests.swift */; };
 		B9DD39B8B4E85E381FDA8A38 /* Routine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EA0C7C01DD431ACCB821AB2 /* Routine.swift */; };
 		CD3D8D2F436141ED8FC420B4 /* EditProductView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81D48775E35C171F249D71F2 /* EditProductView.swift */; };
 		D86A50A7F0413087D59261DE /* ProductDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 764811A1417ABF666878651C /* ProductDetailView.swift */; };
 		E3AB67C5D50261FCDACAB3B2 /* TodayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A7064F2BB7D365F9CFECD1B /* TodayView.swift */; };
+		H1K2S3RV4HK5S6V7C8D9E0 /* HealthKitService.swift in Sources */ = {isa = PBXBuildFile; fileRef = H1K2S3RV4HK5S6V7C8D9E1 /* HealthKitService.swift */; };
 		FC8C798F93A105648A1727FF /* ScheduleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70C98D0FCCDFF4D6778E65EE /* ScheduleView.swift */; };
-		H1K2S3RV4CE5E6A7B8C9D0 /* HealthKitService.swift in Sources */ = {isa = PBXBuildFile; fileRef = H1K2S3RV4CE5E6A7B8C9D1 /* HealthKitService.swift */; };
+		H1K2A3C4C5E6S7S8T9E0S1 /* HealthKitAccessTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = H1K2A3C4C5E6S7S8T9E0S2 /* HealthKitAccessTests.swift */; };
+		I1N2C3I4I5N6G7R8E9D0E1 /* INCIIngredients.swift in Sources */ = {isa = PBXBuildFile; fileRef = I1N2C3I4I5N6G7R8E9D0E0 /* INCIIngredients.swift */; };
 		I2N3G4R5E6D7I8E9N0T1A2 /* IngredientLabelScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = I2N3G4R5E6D7I8E9N0T1A1 /* IngredientLabelScanner.swift */; };
 		I3M4A5G6E7P8I9C0K1E2R3 /* ImagePickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = I3M4A5G6E7P8I9C0K1E2R2 /* ImagePickerView.swift */; };
-		R3M4N5DR6SV7CE8F9A0B1C2 /* ReminderService.swift in Sources */ = {isa = PBXBuildFile; fileRef = R3M4N5DR6SV7CE8F9A0B1C3 /* ReminderService.swift */; };
+		I4N5G6R7E8D9I0E1N2T3A5 /* IngredientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = I4N5G6R7E8D9I0E1N2T3A4 /* IngredientTests.swift */; };
+		I5N6P7U8T9S0A1N2I3T4I6 /* InputSanitizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = I5N6P7U8T9S0A1N2I3T4I5 /* InputSanitizer.swift */; };
 		O1N2B3O4A5R6D7I8N9G001 /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = O1N2B3O4A5R6D7I8N9G002 /* OnboardingView.swift */; };
+		P1C2A3T4E5G6O7R8Y9ABCDEF /* ProductCategory.swift in Sources */ = {isa = PBXBuildFile; fileRef = P1C2A3T4E5G6O7R8Y9ABCDE0 /* ProductCategory.swift */; };
+		R3M4N5DR6SV7CE8F9A0B1C2 /* ReminderService.swift in Sources */ = {isa = PBXBuildFile; fileRef = R3M4N5DR6SV7CE8F9A0B1C3 /* ReminderService.swift */; };
 		R3MT5ST6TS7A1B2C3D4E5F6 /* AddProductTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = R3MT5ST6TS7A1B2C3D4E5F7 /* AddProductTests.swift */; };
 		R3MT5ST6TS7A1B2C3D4E5F8 /* CycleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = R3MT5ST6TS7A1B2C3D4E5F9 /* CycleTests.swift */; };
 		R3MT5ST6TS7A1B2C3D4E5G0 /* ReminderServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = R3MT5ST6TS7A1B2C3D4E5G1 /* ReminderServiceTests.swift */; };
 		R3MT5ST6TS7A1B2C3D4E5G2 /* ViewRenderingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = R3MT5ST6TS7A1B2C3D4E5G3 /* ViewRenderingTests.swift */; };
-		I4N5G6R7E8D9I0E1N2T3A5 /* IngredientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = I4N5G6R7E8D9I0E1N2T3A4 /* IngredientTests.swift */; };
-		H1K2A3C4C5E6S7S8T9E0S1 /* HealthKitAccessTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = H1K2A3C4C5E6S7S8T9E0S2 /* HealthKitAccessTests.swift */; };
 		R3MT5ST6TS7A1B2C3D4E5H2 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = R3MT5ST6TS7A1B2C3D4E5H5 /* XCTest.framework */; };
 		R3MT5ST6TS7A1B2C3D4E5H3 /* SkincareTracker.app in Frameworks */ = {isa = PBXBuildFile; fileRef = 891956B70E0F834744305A1D /* SkincareTracker.app */; };
 		VI1EW2IN3SP4EC5T0R001 /* ViewInspector in Frameworks */ = {isa = PBXBuildFile; productRef = VI1EW2IN3SP4EC5T0R002 /* ViewInspector */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		R3MT5ST6TS7A1B2C3D4E5H4 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = E96D3615280B518EEE99F4AE /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A7FA437BB0024D46D3EC059A;
+			remoteInfo = SkincareTracker;
+		};
+/* End PBXContainerItemProxy section */
+
 /* Begin PBXFileReference section */
+		112233445566778899AABBCC /* AddToCycleSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddToCycleSheet.swift; sourceTree = "<group>"; };
 		1208C60B06EF135F46C71500 /* AddProductView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddProductView.swift; sourceTree = "<group>"; };
 		19F07FC03C73AE8B54505FF3 /* SavedBannerTrigger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SavedBannerTrigger.swift; sourceTree = "<group>"; };
 		2A7064F2BB7D365F9CFECD1B /* TodayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayView.swift; sourceTree = "<group>"; };
@@ -63,31 +76,45 @@
 		81D48775E35C171F249D71F2 /* EditProductView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditProductView.swift; sourceTree = "<group>"; };
 		891956B70E0F834744305A1D /* SkincareTracker.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SkincareTracker.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		9C4550BBFC4C13454DC5FCA9 /* ProductsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsView.swift; sourceTree = "<group>"; };
-		A73038CA622F55888E53CEE9 /* SkincareTrackerApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkincareTrackerApp.swift; sourceTree = "<group>"; };
 		A1P2P3D4E5L6E7G8A9T0E1 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		A73038CA622F55888E53CEE9 /* SkincareTrackerApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkincareTrackerApp.swift; sourceTree = "<group>"; };
 		A78EAA39EB47AD86BE7867A7 /* ReminderConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReminderConfig.swift; sourceTree = "<group>"; };
-		112233445566778899AABBCC /* AddToCycleSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddToCycleSheet.swift; sourceTree = "<group>"; };
+		AP1S2T3A4T5E6P7E8R9S002 /* AppStatePersistence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStatePersistence.swift; sourceTree = "<group>"; };
+		AP1S2T3A4T5E6P7E8R9S004 /* AppStatePersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStatePersistenceTests.swift; sourceTree = "<group>"; };
 		B2D6154E783D16AD56331501 /* CycleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CycleView.swift; sourceTree = "<group>"; };
 		CD7DF4E52182955C00A68E0A /* AppColors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppColors.swift; sourceTree = "<group>"; };
 		E043360F1DD5EC668C8E397D /* ScheduleItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduleItem.swift; sourceTree = "<group>"; };
+		EFFB9F002F6C909F0081171F /* SkincareTrackerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SkincareTrackerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		H1K2S3RV4HK5S6V7C8D9E1 /* HealthKitService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthKitService.swift; sourceTree = "<group>"; };
 		F352F62F49CD44AF927C9615 /* Product.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Product.swift; sourceTree = "<group>"; };
+		H1K2A3C4C5E6S7S8T9E0S2 /* HealthKitAccessTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthKitAccessTests.swift; sourceTree = "<group>"; };
 		I1N2C3I4I5N6G7R8E9D0E0 /* INCIIngredients.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = INCIIngredients.swift; sourceTree = "<group>"; };
-		I5N6P7U8T9S0A1N2I3T4I5 /* InputSanitizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputSanitizer.swift; sourceTree = "<group>"; };
-		P1C2A3T4E5G6O7R8Y9ABCDE0 /* ProductCategory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategory.swift; sourceTree = "<group>"; };
-		H1K2S3RV4CE5E6A7B8C9D1 /* HealthKitService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthKitService.swift; sourceTree = "<group>"; };
 		I2N3G4R5E6D7I8E9N0T1A1 /* IngredientLabelScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IngredientLabelScanner.swift; sourceTree = "<group>"; };
 		I3M4A5G6E7P8I9C0K1E2R2 /* ImagePickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePickerView.swift; sourceTree = "<group>"; };
-		R3M4N5DR6SV7CE8F9A0B1C3 /* ReminderService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReminderService.swift; sourceTree = "<group>"; };
+		I4N5G6R7E8D9I0E1N2T3A4 /* IngredientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IngredientTests.swift; sourceTree = "<group>"; };
+		I5N6P7U8T9S0A1N2I3T4I5 /* InputSanitizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputSanitizer.swift; sourceTree = "<group>"; };
 		O1N2B3O4A5R6D7I8N9G002 /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
+		P1C2A3T4E5G6O7R8Y9ABCDE0 /* ProductCategory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategory.swift; sourceTree = "<group>"; };
+		R3M4N5DR6SV7CE8F9A0B1C3 /* ReminderService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReminderService.swift; sourceTree = "<group>"; };
 		R3MT5ST6TS7A1B2C3D4E5F7 /* AddProductTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddProductTests.swift; sourceTree = "<group>"; };
 		R3MT5ST6TS7A1B2C3D4E5F9 /* CycleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CycleTests.swift; sourceTree = "<group>"; };
 		R3MT5ST6TS7A1B2C3D4E5G1 /* ReminderServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReminderServiceTests.swift; sourceTree = "<group>"; };
 		R3MT5ST6TS7A1B2C3D4E5G3 /* ViewRenderingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewRenderingTests.swift; sourceTree = "<group>"; };
-		I4N5G6R7E8D9I0E1N2T3A4 /* IngredientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IngredientTests.swift; sourceTree = "<group>"; };
-		H1K2A3C4C5E6S7S8T9E0S2 /* HealthKitAccessTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthKitAccessTests.swift; sourceTree = "<group>"; };
-		R3MT5ST6TS7A1B2C3D4E5G4 /* SkincareTrackerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SkincareTrackerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		R3MT5ST6TS7A1B2C3D4E5H5 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
 /* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		R3MT5ST6TS7A1B2C3D4E5G9 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				R3MT5ST6TS7A1B2C3D4E5H2 /* XCTest.framework in Frameworks */,
+				R3MT5ST6TS7A1B2C3D4E5H3 /* SkincareTracker.app in Frameworks */,
+				VI1EW2IN3SP4EC5T0R001 /* ViewInspector in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
 		0A9DE9B700454B178E3A7326 /* Reminders */ = {
@@ -96,14 +123,6 @@
 				769A7F0776C822F50B8C737B /* RemindersView.swift */,
 			);
 			path = Reminders;
-			sourceTree = "<group>";
-		};
-		O1N2B3O4A5R6D7I8N9G003 /* Onboarding */ = {
-			isa = PBXGroup;
-			children = (
-				O1N2B3O4A5R6D7I8N9G002 /* OnboardingView.swift */,
-			);
-			path = Onboarding;
 			sourceTree = "<group>";
 		};
 		1685A7409A382493A7E7FE40 /* Design */ = {
@@ -120,26 +139,15 @@
 				F85277241F8E46CCE7FE4A09 /* SkincareTracker */,
 				R3MT5ST6TS7A1B2C3D4E5G5 /* SkincareTrackerTests */,
 				6515C00DDA42511F788357BC /* Products */,
+				EFFB9EFF2F6C909F0081171F /* Recovered References */,
 			);
-			sourceTree = "<group>";
-		};
-		R3MT5ST6TS7A1B2C3D4E5G5 /* SkincareTrackerTests */ = {
-			isa = PBXGroup;
-			children = (
-				R3MT5ST6TS7A1B2C3D4E5F7 /* AddProductTests.swift */,
-				H1K2A3C4C5E6S7S8T9E0S2 /* HealthKitAccessTests.swift */,
-				I4N5G6R7E8D9I0E1N2T3A4 /* IngredientTests.swift */,
-				R3MT5ST6TS7A1B2C3D4E5F9 /* CycleTests.swift */,
-				R3MT5ST6TS7A1B2C3D4E5G1 /* ReminderServiceTests.swift */,
-				R3MT5ST6TS7A1B2C3D4E5G3 /* ViewRenderingTests.swift */,
-			);
-			path = SkincareTrackerTests;
 			sourceTree = "<group>";
 		};
 		6515C00DDA42511F788357BC /* Products */ = {
 			isa = PBXGroup;
 			children = (
 				891956B70E0F834744305A1D /* SkincareTracker.app */,
+				EFFB9F002F6C909F0081171F /* SkincareTrackerTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -162,6 +170,7 @@
 			isa = PBXGroup;
 			children = (
 				338F7255BE9852B37C01C671 /* AppStore.swift */,
+				AP1S2T3A4T5E6P7E8R9S002 /* AppStatePersistence.swift */,
 				19F07FC03C73AE8B54505FF3 /* SavedBannerTrigger.swift */,
 			);
 			path = AppState;
@@ -199,16 +208,6 @@
 			path = Models;
 			sourceTree = "<group>";
 		};
-		S3RV1C3S4GR0U5P6E7F8A9B0 /* Services */ = {
-			isa = PBXGroup;
-			children = (
-				H1K2S3RV4CE5E6A7B8C9D1 /* HealthKitService.swift */,
-				I2N3G4R5E6D7I8E9N0T1A1 /* IngredientLabelScanner.swift */,
-				R3M4N5DR6SV7CE8F9A0B1C3 /* ReminderService.swift */,
-			);
-			path = Services;
-			sourceTree = "<group>";
-		};
 		DC83F0FAF99EEBC150BF0129 /* Products */ = {
 			isa = PBXGroup;
 			children = (
@@ -229,6 +228,14 @@
 			path = Schedule;
 			sourceTree = "<group>";
 		};
+		EFFB9EFF2F6C909F0081171F /* Recovered References */ = {
+			isa = PBXGroup;
+			children = (
+				R3MT5ST6TS7A1B2C3D4E5H5 /* XCTest.framework */,
+			);
+			name = "Recovered References";
+			sourceTree = "<group>";
+		};
 		F85277241F8E46CCE7FE4A09 /* SkincareTracker */ = {
 			isa = PBXGroup;
 			children = (
@@ -243,6 +250,38 @@
 				6823CCFA0A04B13EEC92D892 /* Views */,
 			);
 			path = SkincareTracker;
+			sourceTree = "<group>";
+		};
+		O1N2B3O4A5R6D7I8N9G003 /* Onboarding */ = {
+			isa = PBXGroup;
+			children = (
+				O1N2B3O4A5R6D7I8N9G002 /* OnboardingView.swift */,
+			);
+			path = Onboarding;
+			sourceTree = "<group>";
+		};
+		R3MT5ST6TS7A1B2C3D4E5G5 /* SkincareTrackerTests */ = {
+			isa = PBXGroup;
+			children = (
+				AP1S2T3A4T5E6P7E8R9S004 /* AppStatePersistenceTests.swift */,
+				R3MT5ST6TS7A1B2C3D4E5F7 /* AddProductTests.swift */,
+				H1K2A3C4C5E6S7S8T9E0S2 /* HealthKitAccessTests.swift */,
+				I4N5G6R7E8D9I0E1N2T3A4 /* IngredientTests.swift */,
+				R3MT5ST6TS7A1B2C3D4E5F9 /* CycleTests.swift */,
+				R3MT5ST6TS7A1B2C3D4E5G1 /* ReminderServiceTests.swift */,
+				R3MT5ST6TS7A1B2C3D4E5G3 /* ViewRenderingTests.swift */,
+			);
+			path = SkincareTrackerTests;
+			sourceTree = "<group>";
+		};
+		S3RV1C3S4GR0U5P6E7F8A9B0 /* Services */ = {
+			isa = PBXGroup;
+			children = (
+				H1K2S3RV4HK5S6V7C8D9E1 /* HealthKitService.swift */,
+				I2N3G4R5E6D7I8E9N0T1A1 /* IngredientLabelScanner.swift */,
+				R3M4N5DR6SV7CE8F9A0B1C3 /* ReminderService.swift */,
+			);
+			path = Services;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -284,7 +323,7 @@
 				VI1EW2IN3SP4EC5T0R002 /* ViewInspector */,
 			);
 			productName = SkincareTrackerTests;
-			productReference = R3MT5ST6TS7A1B2C3D4E5G4 /* SkincareTrackerTests.xctest */;
+			productReference = EFFB9F002F6C909F0081171F /* SkincareTrackerTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
 /* End PBXNativeTarget section */
@@ -338,19 +377,6 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-		R3MT5ST6TS7A1B2C3D4E5G8 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				R3MT5ST6TS7A1B2C3D4E5F6 /* AddProductTests.swift in Sources */,
-				R3MT5ST6TS7A1B2C3D4E5F8 /* CycleTests.swift in Sources */,
-				R3MT5ST6TS7A1B2C3D4E5G0 /* ReminderServiceTests.swift in Sources */,
-				R3MT5ST6TS7A1B2C3D4E5G2 /* ViewRenderingTests.swift in Sources */,
-				H1K2A3C4C5E6S7S8T9E0S1 /* HealthKitAccessTests.swift in Sources */,
-				I4N5G6R7E8D9I0E1N2T3A5 /* IngredientTests.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		AEE82688B0B1C267584DF086 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -358,10 +384,12 @@
 				A58769D6AF2311B1B09CEAB8 /* AddProductView.swift in Sources */,
 				01A870D9AFBFA6C8D2C07458 /* AppColors.swift in Sources */,
 				7D6AA3C9C1AE9B0EDECBBBB1 /* AppStore.swift in Sources */,
+				AP1S2T3A4T5E6P7E8R9S001 /* AppStatePersistence.swift in Sources */,
 				4465B7916BC3337481DF9A85 /* ContentView.swift in Sources */,
 				4AFCCDF488578343A9EA87DF /* CycleView.swift in Sources */,
 				AABBCCDDEEFF112233445566 /* AddToCycleSheet.swift in Sources */,
 				CD3D8D2F436141ED8FC420B4 /* EditProductView.swift in Sources */,
+				H1K2S3RV4HK5S6V7C8D9E0 /* HealthKitService.swift in Sources */,
 				I1N2C3I4I5N6G7R8E9D0E1 /* INCIIngredients.swift in Sources */,
 				I5N6P7U8T9S0A1N2I3T4I6 /* InputSanitizer.swift in Sources */,
 				9534495B6281DE51194DCBFB /* Product.swift in Sources */,
@@ -372,7 +400,6 @@
 				50D4C32BA908C4E6F7C85868 /* ReminderConfig.swift in Sources */,
 				75EE04963A079A11531017EE /* RemindersView.swift in Sources */,
 				O1N2B3O4A5R6D7I8N9G001 /* OnboardingView.swift in Sources */,
-				H1K2S3RV4CE5E6A7B8C9D0 /* HealthKitService.swift in Sources */,
 				I2N3G4R5E6D7I8E9N0T1A2 /* IngredientLabelScanner.swift in Sources */,
 				I3M4A5G6E7P8I9C0K1E2R3 /* ImagePickerView.swift in Sources */,
 				R3M4N5DR6SV7CE8F9A0B1C2 /* ReminderService.swift in Sources */,
@@ -386,20 +413,21 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-/* End PBXSourcesBuildPhase section */
-
-/* Begin PBXFrameworksBuildPhase section */
-		R3MT5ST6TS7A1B2C3D4E5G9 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
+		R3MT5ST6TS7A1B2C3D4E5G8 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				R3MT5ST6TS7A1B2C3D4E5H2 /* XCTest.framework in Frameworks */,
-				R3MT5ST6TS7A1B2C3D4E5H3 /* SkincareTracker.app in Frameworks */,
-				VI1EW2IN3SP4EC5T0R001 /* ViewInspector in Frameworks */,
+				AP1S2T3A4T5E6P7E8R9S003 /* AppStatePersistenceTests.swift in Sources */,
+				R3MT5ST6TS7A1B2C3D4E5F6 /* AddProductTests.swift in Sources */,
+				R3MT5ST6TS7A1B2C3D4E5F8 /* CycleTests.swift in Sources */,
+				R3MT5ST6TS7A1B2C3D4E5G0 /* ReminderServiceTests.swift in Sources */,
+				R3MT5ST6TS7A1B2C3D4E5G2 /* ViewRenderingTests.swift in Sources */,
+				H1K2A3C4C5E6S7S8T9E0S1 /* HealthKitAccessTests.swift in Sources */,
+				I4N5G6R7E8D9I0E1N2T3A5 /* IngredientTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-/* End PBXFrameworksBuildPhase section */
+/* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
 		R3MT5ST6TS7A1B2C3D4E5H1 /* PBXTargetDependency */ = {
@@ -408,35 +436,6 @@
 			targetProxy = R3MT5ST6TS7A1B2C3D4E5H4 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
-
-/* Begin PBXContainerItemProxy section */
-		R3MT5ST6TS7A1B2C3D4E5H4 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = E96D3615280B518EEE99F4AE /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = A7FA437BB0024D46D3EC059A;
-			remoteInfo = SkincareTracker;
-		};
-/* End PBXContainerItemProxy section */
-
-/* Begin XCRemoteSwiftPackageReference section */
-		VI1EW2IN3SP4EC5T0R000 /* XCRemoteSwiftPackageReference "ViewInspector" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/nalexn/ViewInspector";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 0.9.0;
-			};
-		};
-/* End XCRemoteSwiftPackageReference section */
-
-/* Begin XCSwiftPackageProductDependency section */
-		VI1EW2IN3SP4EC5T0R002 /* ViewInspector */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = ViewInspector;
-			package = VI1EW2IN3SP4EC5T0R000 /* XCRemoteSwiftPackageReference "ViewInspector" */;
-		};
-/* End XCSwiftPackageProductDependency section */
 
 /* Begin XCBuildConfiguration section */
 		2C72AAF84A648330BD8497FB /* Debug */ = {
@@ -677,6 +676,25 @@
 			defaultConfigurationName = Debug;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		VI1EW2IN3SP4EC5T0R000 /* XCRemoteSwiftPackageReference "ViewInspector" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/nalexn/ViewInspector";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.9.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		VI1EW2IN3SP4EC5T0R002 /* ViewInspector */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = VI1EW2IN3SP4EC5T0R000 /* XCRemoteSwiftPackageReference "ViewInspector" */;
+			productName = ViewInspector;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = E96D3615280B518EEE99F4AE /* Project object */;
 }

--- a/SkincareTracker/AppState/AppStatePersistence.swift
+++ b/SkincareTracker/AppState/AppStatePersistence.swift
@@ -1,0 +1,103 @@
+//
+//  AppStatePersistence.swift
+//  SkincareTracker
+//
+//  Persists app state to disk so data survives app exit.
+//
+
+import Foundation
+
+/// Codable snapshot of app state for persistence.
+/// Uses string keys for UUIDs where JSON requires string keys.
+private struct PersistedState: Codable {
+    var products: [Product]
+    var routines: [Routine]
+    var cycleProductColors: [String: Int]  // uuidString -> palette index
+    var cycleProductOrder: [String]        // uuidStrings in order
+    var cycleAssignments: [String: [String]]  // "dayIndex-RoutineType" -> [uuidStrings]
+    var cycleStartDate: Date?
+    var cycleLength: Int
+    var putOffRecords: [PutOffRecordCodable]
+    var reminderConfigs: [ReminderConfig]
+}
+
+private struct PutOffRecordCodable: Codable {
+    let productId: UUID
+    let dayString: String
+    let routineType: RoutineType
+}
+
+/// State loaded from disk, ready to apply to AppStore.
+struct LoadedAppState {
+    var products: Set<Product>
+    var routines: [Routine]
+    var cycleProductColors: [UUID: Int]
+    var cycleProductOrder: [UUID]
+    var cycleAssignments: [String: Set<UUID>]
+    var cycleStartDate: Date?
+    var cycleLength: Int
+    var putOffRecords: [(productId: UUID, dayString: String, routineType: RoutineType)]
+    var reminderConfigs: [ReminderConfig]
+}
+
+enum AppStatePersistence {
+    private static let fileName = "app_state.json"
+
+    /// Override for tests to use a temp directory. Set in test setUp, clear in tearDown.
+    static var fileURLOverride: URL?
+
+    static var fileURL: URL {
+        if let override = fileURLOverride { return override }
+        return FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0].appendingPathComponent(fileName)
+    }
+
+    /// Loads persisted state from disk. Returns nil if file doesn't exist or decoding fails.
+    static func load() -> LoadedAppState? {
+        guard FileManager.default.fileExists(atPath: fileURL.path) else { return nil }
+        guard let data = try? Data(contentsOf: fileURL) else { return nil }
+        guard let persisted = try? JSONDecoder().decode(PersistedState.self, from: data) else { return nil }
+        return LoadedAppState(
+            products: Set(persisted.products),
+            routines: persisted.routines,
+            cycleProductColors: Dictionary(uniqueKeysWithValues: persisted.cycleProductColors.compactMap { key, value in
+                guard let uuid = UUID(uuidString: key) else { return nil }
+                return (uuid, value)
+            }),
+            cycleProductOrder: persisted.cycleProductOrder.compactMap { UUID(uuidString: $0) },
+            cycleAssignments: Dictionary(uniqueKeysWithValues: persisted.cycleAssignments.map { key, uuids in
+                (key, Set(uuids.compactMap { UUID(uuidString: $0) }))
+            }),
+            cycleStartDate: persisted.cycleStartDate,
+            cycleLength: persisted.cycleLength,
+            putOffRecords: persisted.putOffRecords.map { ($0.productId, $0.dayString, $0.routineType) },
+            reminderConfigs: persisted.reminderConfigs
+        )
+    }
+
+    /// Saves the given state to disk.
+    static func save(
+        products: Set<Product>,
+        routines: [Routine],
+        cycleProductColors: [UUID: Int],
+        cycleProductOrder: [UUID],
+        cycleAssignments: [String: Set<UUID>],
+        cycleStartDate: Date?,
+        cycleLength: Int,
+        putOffRecords: [(productId: UUID, dayString: String, routineType: RoutineType)],
+        reminderConfigs: [ReminderConfig]
+    ) {
+        let state = PersistedState(
+            products: Array(products),
+            routines: routines,
+            cycleProductColors: Dictionary(uniqueKeysWithValues: cycleProductColors.map { ($0.key.uuidString, $0.value) }),
+            cycleProductOrder: cycleProductOrder.map(\.uuidString),
+            cycleAssignments: cycleAssignments.mapValues { Array($0).map(\.uuidString) },
+            cycleStartDate: cycleStartDate,
+            cycleLength: cycleLength,
+            putOffRecords: putOffRecords.map { PutOffRecordCodable(productId: $0.productId, dayString: $0.dayString, routineType: $0.routineType) },
+            reminderConfigs: reminderConfigs
+        )
+        guard let data = try? JSONEncoder().encode(state) else { return }
+        try? data.write(to: fileURL)
+    }
+}

--- a/SkincareTracker/AppState/AppStore.swift
+++ b/SkincareTracker/AppState/AppStore.swift
@@ -50,9 +50,11 @@ final class AppStore: ObservableObject {
         cycleProductOrder.compactMap { product(by: $0) }
     }
 
-    /// Products not yet assigned to any routine. Sorted by name.
+    /// Products not listed in `cycleProductOrder` (not staged or ordered in the cycle UI). Sorted by name.
+    /// Staged-but-unassigned products are in `cycleProductOrder` only, so they do not appear here—avoids duplicating them in `productsForListView`.
     var productsNotInCycle: [Product] {
-        products.filter { !assignedProductIds.contains($0.id) }.sorted { $0.name < $1.name }
+        let orderedIds = Set(cycleProductOrder)
+        return products.filter { !orderedIds.contains($0.id) }.sorted { $0.name < $1.name }
     }
 
     /// Finds a product by its id.
@@ -152,9 +154,17 @@ final class AppStore: ObservableObject {
     /// Replaces an existing product with the same id, then rebuilds the schedule.
     /// - Parameter product: The updated product (must have an id of an existing product).
     func updateProduct(_ product: Product) {
+        let oldCategoryId = products.first(where: { $0.id == product.id })?.categoryId
         if let existing = products.first(where: { $0.id == product.id }) {
             products.remove(existing)
             products.insert(product)
+        }
+        if shouldRepositionInCycleAfterCategoryChange(from: oldCategoryId, to: product.categoryId) {
+            repositionProductInCycleOrderByCategory(productId: product.id)
+            if !cycleAssignments.isEmpty {
+                hasUnsavedCycleChanges = true
+                applyCycleToRoutines()
+            }
         }
         rebuildSchedule(from: Date())
     }
@@ -237,7 +247,24 @@ final class AppStore: ObservableObject {
     func addProductToCycle(_ product: Product) {
         guard products.contains(product) else { return }
         guard !cycleProductOrder.contains(product.id) else { return }
+        insertProductIdInCycleOrderByCategory(product.id)
+        // Don't assign color here: color is given only when product is added to a routine (assignProductToCycleSlot).
+        // Don't set hasUnsavedCycleChanges: adding without assigning to a day slot doesn't affect the schedule.
+    }
 
+    /// Nil and `"other"` both map to the default “Other” step (last in category order).
+    private func isEffectivelyOtherCategory(_ categoryId: String?) -> Bool {
+        (categoryId ?? "other") == "other"
+    }
+
+    /// When a product was uncategorized (“Other”) and gets a specific category, it should move in `cycleProductOrder` like a newly added product.
+    private func shouldRepositionInCycleAfterCategoryChange(from oldCategoryId: String?, to newCategoryId: String?) -> Bool {
+        isEffectivelyOtherCategory(oldCategoryId) && !isEffectivelyOtherCategory(newCategoryId)
+    }
+
+    /// Inserts `productId` into `cycleProductOrder` by application order (same rules as adding to the cycle). Caller must ensure the id is not already present.
+    private func insertProductIdInCycleOrderByCategory(_ productId: UUID) {
+        guard let product = product(by: productId) else { return }
         let productOrder = ProductCategory.applicationOrder(for: product.categoryId)
         var insertIndex = cycleProductOrder.count
         for (i, id) in cycleProductOrder.enumerated() {
@@ -247,9 +274,14 @@ final class AppStore: ObservableObject {
                 break
             }
         }
-        cycleProductOrder.insert(product.id, at: insertIndex)
-        // Don't assign color here: color is given only when product is added to a routine (assignProductToCycleSlot).
-        // Don't set hasUnsavedCycleChanges: adding without assigning to a day slot doesn't affect the schedule.
+        cycleProductOrder.insert(productId, at: insertIndex)
+    }
+
+    /// Removes and reinserts the product by category order so “Other” → specific category updates routine order.
+    private func repositionProductInCycleOrderByCategory(productId: UUID) {
+        guard cycleProductOrder.contains(productId) else { return }
+        cycleProductOrder.removeAll { $0 == productId }
+        insertProductIdInCycleOrderByCategory(productId)
     }
 
     /// Removes a product from cycle and clears its assigned color.
@@ -404,7 +436,34 @@ final class AppStore: ObservableObject {
     }
     
     init() {
+        if let loaded = AppStatePersistence.load() {
+            products = loaded.products
+            routines = loaded.routines
+            cycleProductColors = loaded.cycleProductColors
+            cycleProductOrder = loaded.cycleProductOrder
+            cycleAssignments = loaded.cycleAssignments
+            cycleStartDate = loaded.cycleStartDate
+            cycleLength = loaded.cycleLength
+            putOffRecords = Set(loaded.putOffRecords.map { PutOffRecord(productId: $0.productId, dayString: $0.dayString, routineType: $0.routineType) })
+            reminderConfigs = loaded.reminderConfigs
+            hasUnsavedCycleChanges = false
+        }
         rebuildSchedule(from: Date())
+    }
+
+    /// Persists app state to disk. Call when app enters background or before exit.
+    func saveToDisk() {
+        AppStatePersistence.save(
+            products: products,
+            routines: routines,
+            cycleProductColors: cycleProductColors,
+            cycleProductOrder: cycleProductOrder,
+            cycleAssignments: cycleAssignments,
+            cycleStartDate: cycleStartDate,
+            cycleLength: cycleLength,
+            putOffRecords: putOffRecords.map { (productId: $0.productId, dayString: $0.dayString, routineType: $0.routineType) },
+            reminderConfigs: reminderConfigs
+        )
     }
     
     // MARK: - Cycle

--- a/SkincareTracker/Info.plist
+++ b/SkincareTracker/Info.plist
@@ -18,16 +18,18 @@
 	<string>1.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
-	<key>NSCameraUsageDescription</key>
-	<string>Skincare Tracker uses the camera to scan ingredient lists on product labels.</string>
-	<key>NSPhotoLibraryUsageDescription</key>
-	<string>Skincare Tracker needs photo library access to scan ingredient lists from product label photos.</string>
 	<key>NSCalendarsUsageDescription</key>
 	<string>Skincare Tracker needs calendar access to schedule reminders for your skincare routine.</string>
+	<key>NSCameraUsageDescription</key>
+	<string>Skincare Tracker uses the camera to scan ingredient lists on product labels.</string>
+	<key>NSHealthShareUsageDescription</key>
+	<string>Skincare Tracker uses your sleep data to send you routine reminders when you wake up and before you go to sleep.</string>
+	<key>NSHealthUpdateUsageDescription</key>
+	<string>Skincare Tracker only reads sleep data from Health to schedule reminders; it does not write health data.</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>Skincare Tracker needs photo library access to scan ingredient lists from product label photos.</string>
 	<key>NSUserNotificationsUsageDescription</key>
 	<string>Skincare Tracker sends reminders for when to apply your skincare products.</string>
-	<key>NSHealthShareUsageDescription</key>
-	<string>Skincare Tracker uses your sleep data to remind you 1 hour before bedtime for your night routine.</string>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>remote-notification</string>

--- a/SkincareTracker/Services/HealthKitService.swift
+++ b/SkincareTracker/Services/HealthKitService.swift
@@ -2,7 +2,7 @@
 //  HealthKitService.swift
 //  SkincareTracker
 //
-//  Reads sleep data from Health for bedtime and wake-up reminder scheduling.
+//  Health authorization and reminder-oriented sleep time queries (`HealthKitServiceBase` for tests).
 //
 
 import Foundation
@@ -10,24 +10,48 @@ import HealthKit
 
 /// Base type for HealthKit access; enables injecting mocks in tests.
 open class HealthKitServiceBase: ObservableObject {
-    /// Whether HealthKit is available. Override in tests to return true.
     open class var isAvailable: Bool {
         HKHealthStore.isHealthDataAvailable()
     }
+
+    /// Prefer this over `type(of: service).isAvailable` in views; avoids runtime issues with `@EnvironmentObject`.
+    var isHealthKitDataAvailable: Bool { Self.isAvailable }
+
     open func requestAuthorization() async throws { fatalError("subclass must implement") }
     open func fetchTypicalBedtime() async -> (hour: Int, minute: Int)? { nil }
     open func fetchTypicalWakeTime() async -> (hour: Int, minute: Int)? { nil }
 }
 
-/// Fetches bedtime and wake time from Health app sleep data (in-bed samples).
+/// Performs Health authorization and reminder-oriented sleep time queries.
 final class HealthKitService: HealthKitServiceBase {
     private let healthStore = HKHealthStore()
 
-    /// Requests authorization to read sleep analysis. Call before fetching bedtime.
     override func requestAuthorization() async throws {
         guard Self.isAvailable else { return }
-        guard let sleepType = HKObjectType.categoryType(forIdentifier: .sleepAnalysis) else { return }
-        try await healthStore.requestAuthorization(toShare: [], read: [sleepType])
+        let store = healthStore
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            DispatchQueue.main.async {
+                DispatchQueue.main.async {
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+                        Task { @MainActor in
+                            await Self.requestSleepReadAuthorization(healthStore: store)
+                            continuation.resume()
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private static func requestSleepReadAuthorization(healthStore: HKHealthStore) async {
+        guard let sleepType = HKObjectType.categoryType(forIdentifier: .sleepAnalysis) else {
+            return
+        }
+        let readTypes: Set<HKObjectType> = [sleepType]
+        let shareTypes: Set<HKSampleType> = []
+        do {
+            try await healthStore.requestAuthorization(toShare: shareTypes, read: readTypes)
+        } catch {}
     }
 
     /// Returns typical bedtime (hour and minute) from recent in-bed samples, or nil if unavailable.

--- a/SkincareTracker/SkincareTracker.entitlements
+++ b/SkincareTracker/SkincareTracker.entitlements
@@ -4,5 +4,7 @@
 <dict>
 	<key>com.apple.developer.healthkit</key>
 	<true/>
+	<key>com.apple.developer.healthkit.background-delivery</key>
+	<true/>
 </dict>
 </plist>

--- a/SkincareTracker/Views/ContentView.swift
+++ b/SkincareTracker/Views/ContentView.swift
@@ -13,27 +13,46 @@ struct ContentView: View {
     @StateObject private var store = AppStore()
     @StateObject private var savedBanner = SavedBannerTrigger()
     @StateObject private var reminderService = ReminderService()
-    @StateObject private var healthKitService: HealthKitServiceBase = HealthKitService()
+    @StateObject private var healthKitService = HealthKitService()
     @State private var showOnboarding = !OnboardingView.hasCompletedOnboarding
     @State private var selectedTab: AppTab = .today
+    @Environment(\.scenePhase) private var scenePhase
 
     var body: some View {
-        TabView(selection: $selectedTab) {
-            TodayView()
-                .tabItem { Label("Today", systemImage: "sun.max.fill") }
-                .tag(AppTab.today)
+        ZStack {
+            TabView(selection: $selectedTab) {
+                TodayView()
+                    .tabItem { Label("Today", systemImage: "sun.max.fill") }
+                    .tag(AppTab.today)
 
-            CycleView()
-                .tabItem { Label("Cycle", systemImage: "arrow.2.circlepath") }
-                .tag(AppTab.cycle)
+                CycleView()
+                    .tabItem { Label("Cycle", systemImage: "arrow.2.circlepath") }
+                    .tag(AppTab.cycle)
 
-            ProductsView()
-                .tabItem { Label("Products", systemImage: "drop.fill") }
-                .tag(AppTab.products)
+                ProductsView()
+                    .tabItem { Label("Products", systemImage: "drop.fill") }
+                    .tag(AppTab.products)
 
-            RemindersView()
-                .tabItem { Label("Reminders", systemImage: "bell.fill") }
-                .tag(AppTab.reminders)
+                RemindersView()
+                    .tabItem { Label("Reminders", systemImage: "bell.fill") }
+                    .tag(AppTab.reminders)
+            }
+            // Onboarding as a root overlay (not fullScreenCover) so HealthKit’s permission UI can present and
+            // complete reliably on device. Nested modals often leave authorization callbacks stuck on real hardware.
+            if showOnboarding {
+                OnboardingView(onComplete: {
+                    showOnboarding = false
+                })
+                .environmentObject(store)
+                .environmentObject(savedBanner)
+                .environmentObject(reminderService)
+                .environmentObject(healthKitService as HealthKitServiceBase)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .background(AppColors.background)
+                .ignoresSafeArea()
+                .transition(.opacity)
+                .zIndex(1)
+            }
         }
         .onReceive(NotificationCenter.default.publisher(for: .openTodayTab)) { _ in
             selectedTab = .today
@@ -50,13 +69,18 @@ struct ContentView: View {
                 selectedTab = .today
             }
         }
+        .onChange(of: scenePhase) { _, newPhase in
+            if newPhase == .background {
+                store.saveToDisk()
+            }
+        }
         .foregroundStyle(AppColors.textPrimary)
         .background(AppColors.background)
         .tint(AppColors.accent)
         .environmentObject(store)
         .environmentObject(savedBanner)
         .environmentObject(reminderService)
-        .environmentObject(healthKitService)
+        .environmentObject(healthKitService as HealthKitServiceBase)
         .overlay(alignment: .bottom) {
             if savedBanner.isShowing {
                 HStack(spacing: 8) {
@@ -75,15 +99,7 @@ struct ContentView: View {
             }
         }
         .animation(.easeInOut(duration: 0.25), value: savedBanner.isShowing)
-        .fullScreenCover(isPresented: $showOnboarding) {
-            OnboardingView(onComplete: {
-                showOnboarding = false
-            })
-            .environmentObject(store)
-            .environmentObject(savedBanner)
-            .environmentObject(reminderService)
-            .environmentObject(healthKitService)
-        }
+        .animation(.easeInOut(duration: 0.25), value: showOnboarding)
     }
 }
 

--- a/SkincareTracker/Views/Cycle/CycleView.swift
+++ b/SkincareTracker/Views/Cycle/CycleView.swift
@@ -7,6 +7,10 @@
 
 import SwiftUI
 
+/// Layout constants for CycleView. productListRowHeight must be >= 58 to prevent the last product row from being cut off.
+enum CycleViewLayout {
+    static let productListRowHeight: CGFloat = 58
+}
 
 struct CycleView: View {
     @EnvironmentObject var store: AppStore
@@ -27,6 +31,7 @@ struct CycleView: View {
                     instructionsSection
                 }
                 .padding()
+                .padding(.bottom, store.hasUnsavedCycleChanges ? 72 : 0)
             }
             .background(AppColors.background)
             .navigationTitle("Skincare Cycle")
@@ -180,7 +185,8 @@ struct CycleView: View {
                 .listStyle(.plain)
                 .scrollContentBackground(.hidden)
                 .scrollDisabled(true)
-                .frame(minHeight: CGFloat(store.productsInCycleOrdered.count) * 52)
+                .contentMargins(.bottom, 12, for: .scrollContent)
+                .frame(minHeight: CGFloat(store.productsInCycleOrdered.count) * CycleViewLayout.productListRowHeight)
                 .padding(.bottom, 8)
             }
             

--- a/SkincareTracker/Views/Cycle/CycleView.swift
+++ b/SkincareTracker/Views/Cycle/CycleView.swift
@@ -131,12 +131,13 @@ struct CycleView: View {
                 .tint(AppColors.accent)
             }
             
-            if store.productsInCycle.isEmpty {
+            if store.productsInCycleOrdered.isEmpty {
                 Text("No products in cycle. Tap Add to add from your collection or add a new product.")
                     .font(.subheadline)
                     .foregroundStyle(AppColors.textSecondary)
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, 24)
+                    .accessibilityIdentifier("cycle-empty-state")
             } else {
                 List {
                     ForEach(store.productsInCycleOrdered) { product in
@@ -188,6 +189,7 @@ struct CycleView: View {
                 .contentMargins(.bottom, 12, for: .scrollContent)
                 .frame(minHeight: CGFloat(store.productsInCycleOrdered.count) * CycleViewLayout.productListRowHeight)
                 .padding(.bottom, 8)
+                .accessibilityIdentifier("cycle-product-list")
             }
             
             if selectedProductId != nil {

--- a/SkincareTracker/Views/Onboarding/OnboardingView.swift
+++ b/SkincareTracker/Views/Onboarding/OnboardingView.swift
@@ -7,40 +7,28 @@
 
 import SwiftUI
 
-/// Optional override for Health access action. Used in tests to invoke the action directly without simulating a tap.
-private struct HealthAccessRequestActionKey: EnvironmentKey {
-    static let defaultValue: (() async -> Void)? = nil
-}
-extension EnvironmentValues {
-    var healthAccessRequestAction: (() async -> Void)? {
-        get { self[HealthAccessRequestActionKey.self] }
-        set { self[HealthAccessRequestActionKey.self] = newValue }
-    }
-}
-
 struct OnboardingView: View {
     @EnvironmentObject var store: AppStore
     @EnvironmentObject var reminderService: ReminderService
     @EnvironmentObject var healthKitService: HealthKitServiceBase
-    @Environment(\.healthAccessRequestAction) private var healthAccessRequestAction
 
     let onComplete: () -> Void
 
-    @State private var wantsReminders = true
-    @State private var isRequestingHealth = false
+    @State private var wantsNotifications = false
+    @State private var syncRemindersWithHealthSleep = false
     @State private var isRequestingNotifications = false
+    @State private var isRequestingHealth = false
+
+    private var healthKitAvailable: Bool {
+        healthKitService.isHealthKitDataAvailable
+    }
 
     var body: some View {
         ScrollView {
             VStack(spacing: 32) {
                 header
 
-                if type(of: healthKitService).isAvailable {
-                    healthSection
-                }
-
                 notificationsSection
-                remindersToggle
 
                 continueButton
             }
@@ -61,57 +49,6 @@ struct OnboardingView: View {
                 .multilineTextAlignment(.center)
         }
         .padding(.top, 24)
-    }
-
-    private var healthSection: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            HStack(spacing: 12) {
-                Image(systemName: "heart.fill")
-                    .font(.title2)
-                    .foregroundStyle(AppColors.textOnAccent)
-                    .frame(width: 44, height: 44)
-                    .background(AppColors.accent)
-                    .clipShape(Circle())
-
-                VStack(alignment: .leading, spacing: 4) {
-                    Text("Health app")
-                        .font(.headline)
-                        .foregroundStyle(AppColors.textPrimary)
-                    Text("We use your sleep data to remind you at the right times—when you wake up and before bed.")
-                        .font(.subheadline)
-                        .foregroundStyle(AppColors.textSecondary)
-                }
-            }
-            .padding()
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .background(AppColors.surface)
-            .clipShape(RoundedRectangle(cornerRadius: 16))
-
-            Button {
-                if let action = healthAccessRequestAction {
-                    Task { await action() }
-                } else {
-                    Task { await requestHealthAccess() }
-                }
-            } label: {
-                HStack {
-                    if isRequestingHealth {
-                        ProgressView()
-                            .tint(AppColors.textOnAccent)
-                    } else {
-                        Text("Allow Health Access")
-                            .fontWeight(.medium)
-                    }
-                }
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, 14)
-                .background(AppColors.accent)
-                .foregroundStyle(AppColors.textOnAccent)
-                .clipShape(RoundedRectangle(cornerRadius: 12))
-            }
-            .accessibilityIdentifier("allowHealthAccess")
-            .disabled(isRequestingHealth)
-        }
     }
 
     private var notificationsSection: some View {
@@ -138,43 +75,62 @@ struct OnboardingView: View {
             .background(AppColors.surface)
             .clipShape(RoundedRectangle(cornerRadius: 16))
 
-            Button {
-                Task { await requestNotificationPermission() }
-            } label: {
-                HStack {
+            Toggle(isOn: $wantsNotifications) {
+                HStack(spacing: 8) {
                     if isRequestingNotifications {
                         ProgressView()
-                            .tint(AppColors.textOnAccent)
-                    } else {
-                        Text("Enable Notifications")
-                            .fontWeight(.medium)
+                            .scaleEffect(0.9)
+                    }
+                    Text("Enable morning & night reminders")
+                        .fontWeight(.medium)
+                        .foregroundStyle(AppColors.textPrimary)
+                }
+            }
+            .accessibilityIdentifier("enableRemindersToggle")
+            .tint(.green)
+            .padding()
+            .background(AppColors.surface)
+            .clipShape(RoundedRectangle(cornerRadius: 16))
+            .disabled(isRequestingNotifications)
+            .onChange(of: wantsNotifications) { _, isOn in
+                if isOn {
+                    Task { @MainActor in
+                        await requestNotificationPermission()
+                    }
+                } else {
+                    syncRemindersWithHealthSleep = false
+                }
+            }
+
+            if wantsNotifications, healthKitAvailable {
+                Toggle(isOn: $syncRemindersWithHealthSleep) {
+                    HStack(spacing: 8) {
+                        if isRequestingHealth {
+                            ProgressView()
+                                .scaleEffect(0.9)
+                        }
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text("Sync with reminders with your Health app sleep schedule")
+                                .fontWeight(.medium)
+                                .foregroundStyle(AppColors.textPrimary)
+                        }
                     }
                 }
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, 14)
-                .background(AppColors.accent)
-                .foregroundStyle(AppColors.textOnAccent)
-                .clipShape(RoundedRectangle(cornerRadius: 12))
-            }
-            .disabled(isRequestingNotifications)
-        }
-    }
-
-    private var remindersToggle: some View {
-        Toggle(isOn: $wantsReminders) {
-            VStack(alignment: .leading, spacing: 4) {
-                Text("Morning & night reminders")
-                    .font(.headline)
-                    .foregroundStyle(AppColors.textPrimary)
-                Text("Get reminded every morning and night for your skincare routine.")
-                    .font(.subheadline)
-                    .foregroundStyle(AppColors.textSecondary)
+                .tint(.green)
+                .padding()
+                .background(AppColors.surface)
+                .clipShape(RoundedRectangle(cornerRadius: 16))
+                .accessibilityIdentifier("healthSleepSyncToggle")
+                .disabled(isRequestingHealth)
+                .onChange(of: syncRemindersWithHealthSleep) { _, isOn in
+                    if isOn {
+                        Task { @MainActor in
+                            await requestHealthAccessWithWatchdog()
+                        }
+                    }
+                }
             }
         }
-        .tint(.green)
-        .padding()
-        .background(AppColors.surface)
-        .clipShape(RoundedRectangle(cornerRadius: 16))
     }
 
     private var continueButton: some View {
@@ -192,12 +148,30 @@ struct OnboardingView: View {
         .padding(.top, 8)
     }
 
-    private func requestHealthAccess() async {
+    /// Runs Health authorization off the SwiftUI `onChange` turn (see `HealthKitService`) and clears the spinner
+    /// after a timeout if the system never calls back (beta OS / presentation bugs).
+    @MainActor
+    private func requestHealthAccessWithWatchdog() async {
         isRequestingHealth = true
-        defer { isRequestingHealth = false }
+
+        let watchdog = Task { @MainActor in
+            try? await Task.sleep(for: .seconds(30))
+            guard !Task.isCancelled else { return }
+            isRequestingHealth = false
+            syncRemindersWithHealthSleep = false
+        }
+
+        await Self.performHealthAuthorizationRequest(healthKitService: healthKitService)
+        watchdog.cancel()
+        isRequestingHealth = false
+    }
+
+    /// Same authorization path as the Health sleep sync toggle; used by `HealthKitAccessTests`.
+    static func performHealthAuthorizationRequest(healthKitService: HealthKitServiceBase) async {
         try? await healthKitService.requestAuthorization()
     }
 
+    @MainActor
     private func requestNotificationPermission() async {
         isRequestingNotifications = true
         defer { isRequestingNotifications = false }
@@ -205,11 +179,14 @@ struct OnboardingView: View {
     }
 
     private func completeOnboarding() {
-        if wantsReminders {
+        if wantsNotifications {
             var morningConfig = store.reminderConfig(for: .morning)
             var nightConfig = store.reminderConfig(for: .night)
             morningConfig.isEnabled = true
             nightConfig.isEnabled = true
+            let useHealth = syncRemindersWithHealthSleep && healthKitAvailable
+            morningConfig.useHealthWakeTime = useHealth
+            nightConfig.useHealthBedtime = useHealth
             store.updateReminderConfig(morningConfig)
             store.updateReminderConfig(nightConfig)
             Task {
@@ -250,8 +227,9 @@ struct OnboardingView: View {
 }
 
 #Preview {
+    let health = HealthKitService()
     OnboardingView(onComplete: {})
         .environmentObject(AppStore())
         .environmentObject(ReminderService())
-        .environmentObject(HealthKitService())
+        .environmentObject(health as HealthKitServiceBase)
 }

--- a/SkincareTracker/Views/Reminders/RemindersView.swift
+++ b/SkincareTracker/Views/Reminders/RemindersView.swift
@@ -28,7 +28,7 @@ struct RemindersView: View {
                 ForEach(RoutineType.allCases, id: \.self) { routineType in
                     ReminderRowView(
                         config: store.reminderConfig(for: routineType),
-                        healthKitAvailable: Swift.type(of: healthKitService).isAvailable,
+                        healthKitAvailable: healthKitService.isHealthKitDataAvailable,
                         onSave: { config in
                             store.updateReminderConfig(config)
                             Task { await rescheduleReminders() }
@@ -133,7 +133,7 @@ struct ReminderRowView: View {
                     .listRowBackground(AppColors.rowBackground)
             }
 
-            if useHealthWakeTime && isMorningRoutine {
+            if healthKitAvailable && useHealthWakeTime && isMorningRoutine {
                 HStack {
                     Text("Time")
                         .foregroundStyle(AppColors.textPrimary)
@@ -142,7 +142,7 @@ struct ReminderRowView: View {
                         .foregroundStyle(AppColors.textSecondary)
                 }
                 .listRowBackground(AppColors.rowBackground)
-            } else if useHealthBedtime && isNightRoutine {
+            } else if healthKitAvailable && useHealthBedtime && isNightRoutine {
                 HStack {
                     Text("Time")
                         .foregroundStyle(AppColors.textPrimary)
@@ -193,8 +193,9 @@ struct ReminderRowView: View {
 }
 
 #Preview {
+    let health = HealthKitService()
     RemindersView()
         .environmentObject(AppStore())
         .environmentObject(ReminderService())
-        .environmentObject(HealthKitService())
+        .environmentObject(health as HealthKitServiceBase)
 }

--- a/SkincareTrackerTests/AddProductTests.swift
+++ b/SkincareTrackerTests/AddProductTests.swift
@@ -309,6 +309,23 @@ final class AddProductTests: XCTestCase {
         XCTAssertEqual(notInCycle, ["B"])
     }
 
+    /// Regression: staged products (in `cycleProductOrder` but not assigned to any day) must not appear in both
+    /// `productsInCycleOrdered` and `productsNotInCycle`. Without the fix, `productsForListView` concatenates both and duplicates IDs.
+    func testProductsForListView_stagedUnassignedProductAppearsOnce() throws {
+        let staged = Product(name: "StagedOnly", ingredientNames: [])
+        let other = Product(name: "ZebraOther", ingredientNames: [])
+        store.addProduct(staged)
+        store.addProduct(other)
+        store.addProductToCycle(staged)
+        XCTAssertTrue(store.productsInCycle.isEmpty, "Precondition: staged product must not be assigned to any slot")
+
+        let list = store.productsForListView
+        // Buggy `productsNotInCycle` used `!assignedProductIds` only, so staged rows appeared twice → count 3, duplicate UUIDs.
+        XCTAssertEqual(list.count, 2, "Each catalog product should appear exactly once in the Products tab list")
+        XCTAssertEqual(list.filter { $0.id == staged.id }.count, 1)
+        XCTAssertEqual(Set(list.map(\.id)).count, list.count, "List must not contain duplicate product IDs")
+    }
+
     func testProductsInCycleOrdered_followsCycleOrder() throws {
         let a = Product(name: "A", ingredientNames: [])
         let b = Product(name: "B", ingredientNames: [])
@@ -464,6 +481,39 @@ final class AddProductTests: XCTestCase {
         store.addProduct(product)
         store.updateProduct(productId: product.id, categoryId: "serum")
         XCTAssertEqual(store.product(by: product.id)?.categoryId, "serum")
+    }
+
+    /// Edit Product saves with `updateProduct(productId:categoryId:)`; picker stores Other as `"other"`.
+    /// Without cycle reorder, `cycleProductOrder` would stay [toner, cream, mystery] after changing to serum.
+    func testUpdateProduct_fromPickerOtherToSerum_reordersCycleProductOrder() throws {
+        let toner = Product(name: "Toner", ingredientNames: [], categoryId: "toner")
+        let cream = Product(name: "Cream", ingredientNames: [], categoryId: "cream")
+        let mystery = Product(name: "Mystery", ingredientNames: [], categoryId: "other")
+        store.addProduct(toner)
+        store.addProduct(cream)
+        store.addProduct(mystery)
+        store.cycleLength = 7
+        store.assignProductToCycleSlot(productId: toner.id, dayIndex: 0, routineType: .morning)
+        store.assignProductToCycleSlot(productId: cream.id, dayIndex: 0, routineType: .morning)
+        store.assignProductToCycleSlot(productId: mystery.id, dayIndex: 0, routineType: .morning)
+
+        XCTAssertEqual(store.cycleProductOrder, [toner.id, cream.id, mystery.id])
+
+        store.updateProduct(productId: mystery.id, categoryId: "serum")
+
+        XCTAssertNotEqual(
+            store.cycleProductOrder,
+            [toner.id, cream.id, mystery.id],
+            "Regression guard: unfixed app keeps stale order with serum still after cream"
+        )
+        XCTAssertEqual(store.cycleProductOrder, [toner.id, mystery.id, cream.id])
+
+        let slotProducts = store.productsOnCycleSlot(dayIndex: 0, routineType: .morning)
+            .compactMap { store.product(by: $0) }
+        XCTAssertEqual(
+            store.productsSortedByCycleOrder(slotProducts).map(\.name),
+            ["Toner", "Mystery", "Cream"]
+        )
     }
 
     func testUpdateProduct_withCategoryIdNil_keepsExisting() throws {

--- a/SkincareTrackerTests/AppStatePersistenceTests.swift
+++ b/SkincareTrackerTests/AppStatePersistenceTests.swift
@@ -1,0 +1,101 @@
+//
+//  AppStatePersistenceTests.swift
+//  SkincareTrackerTests
+//
+//  Verifies that app state is saved and restored correctly when the user exits the app.
+//
+//  To verify tests fail when persistence is NOT implemented:
+//  1. In AppStore.init: comment out the "if let loaded = AppStatePersistence.load()" block
+//  2. In AppStore.saveToDisk: add "return" as the first line (before AppStatePersistence.save)
+//  3. Run: xcodebuild test -scheme SkincareTracker -destination 'platform=iOS Simulator,name=iPhone 16' -only-testing:SkincareTrackerTests/AppStatePersistenceTests
+//  4. Expect: testSaveToDisk_writesStateFileToDisk, testSaveAndLoad_withCycleEdits_*, testSaveAndLoad_unsavedCycleEdits_* FAIL
+//  5. Restore the persistence code; all tests should pass.
+//
+
+import XCTest
+@testable import SkincareTracker
+
+@MainActor
+final class AppStatePersistenceTests: XCTestCase {
+
+    private var testFileURL: URL!
+
+    override func setUpWithError() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+        testFileURL = tempDir.appendingPathComponent(UUID().uuidString).appendingPathComponent("app_state.json")
+        try FileManager.default.createDirectory(at: testFileURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        AppStatePersistence.fileURLOverride = testFileURL
+    }
+
+    override func tearDownWithError() throws {
+        AppStatePersistence.fileURLOverride = nil
+        try? FileManager.default.removeItem(at: testFileURL)
+        try? FileManager.default.removeItem(at: testFileURL.deletingLastPathComponent())
+    }
+
+    // MARK: - Save Writes to Disk
+
+    /// Fails when saveToDisk is a no-op (fix not implemented). The state file must exist after save.
+    func testSaveToDisk_writesStateFileToDisk() throws {
+        let store = AppStore()
+        store.addProduct(Product(name: "Test", ingredientNames: []))
+        store.saveToDisk()
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: testFileURL.path),
+                      "saveToDisk must write app_state.json when app exits; fails when persistence is not implemented")
+    }
+
+    // MARK: - No Edits (Empty State)
+
+    /// When the user exits with no data and no edits, save preserves empty state and load restores it.
+    func testSaveAndLoad_emptyState_preservesEmptyStateAfterAppExit() throws {
+        let store = AppStore()
+        XCTAssertTrue(store.products.isEmpty, "Fresh store should have no products")
+        XCTAssertTrue(store.cycleAssignments.isEmpty, "Fresh store should have no cycle assignments")
+
+        store.saveToDisk()
+
+        let restoredStore = AppStore()
+        XCTAssertTrue(restoredStore.products.isEmpty, "After app exit, products should remain empty")
+        XCTAssertTrue(restoredStore.cycleAssignments.isEmpty, "After app exit, cycle assignments should remain empty")
+        XCTAssertNil(restoredStore.cycleStartDate, "After app exit, cycleStartDate should remain nil")
+    }
+
+    // MARK: - With Edits (Cycle + Products)
+
+    /// When the user adds products, configures the cycle, and exits, state is restored on next launch.
+    func testSaveAndLoad_withCycleEdits_restoresStateAfterAppExit() throws {
+        let product = Product(name: "Vitamin C Serum", ingredientNames: ["Vitamin C", "Hyaluronic Acid"])
+        let store = AppStore()
+        store.addProduct(product)
+        store.assignProductToCycleSlot(productId: product.id, dayIndex: 0, routineType: .morning)
+        store.assignProductToCycleSlot(productId: product.id, dayIndex: 1, routineType: .night)
+        store.setCycleLength(7)
+        store.saveCycle()
+
+        store.saveToDisk()
+
+        let restoredStore = AppStore()
+        XCTAssertEqual(restoredStore.products.count, 1, "Product should be restored")
+        XCTAssertEqual(restoredStore.sortedProducts.first?.name, "Vitamin C Serum", "Product name should match")
+        XCTAssertTrue(restoredStore.productsOnCycleSlot(dayIndex: 0, routineType: .morning).contains(product.id), "Day 0 morning assignment should be restored")
+        XCTAssertTrue(restoredStore.productsOnCycleSlot(dayIndex: 1, routineType: .night).contains(product.id), "Day 1 night assignment should be restored")
+        XCTAssertNotNil(restoredStore.cycleStartDate, "cycleStartDate should be restored")
+        XCTAssertEqual(restoredStore.cycleLength, 7, "cycleLength should be restored")
+    }
+
+    /// When the user makes edits but does not tap Save in the Cycle UI, unsaved cycle changes are still persisted on app exit.
+    func testSaveAndLoad_unsavedCycleEdits_persistsOnAppExit() throws {
+        let product = Product(name: "Retinol", ingredientNames: [])
+        let store = AppStore()
+        store.addProduct(product)
+        store.assignProductToCycleSlot(productId: product.id, dayIndex: 2, routineType: .morning)
+        XCTAssertTrue(store.hasUnsavedCycleChanges, "Assigning without save should mark unsaved")
+
+        store.saveToDisk()
+
+        let restoredStore = AppStore()
+        XCTAssertTrue(restoredStore.productsOnCycleSlot(dayIndex: 2, routineType: .morning).contains(product.id),
+                     "Unsaved cycle edits should be persisted when app exits (saveToDisk called on background)")
+    }
+}

--- a/SkincareTrackerTests/CycleTests.swift
+++ b/SkincareTrackerTests/CycleTests.swift
@@ -159,6 +159,55 @@ final class CycleTests: XCTestCase {
         XCTAssertTrue(store.nightRoutine.productIds.contains(productB.id), "B should be in night routine")
     }
 
+    /// Changing category from default “Other” to a specific step should reinsert the product in `cycleProductOrder` (same rules as adding to the cycle).
+    func testUpdateProduct_fromOtherToSpecificCategory_reordersCycleAndMorningRoutine() throws {
+        let toner = Product(name: "Toner", ingredientNames: [], categoryId: "toner")
+        let cream = Product(name: "Cream", ingredientNames: [], categoryId: "cream")
+        let wasOther = Product(name: "Mystery", ingredientNames: [], categoryId: nil)
+        store.addProduct(toner)
+        store.addProduct(cream)
+        store.addProduct(wasOther)
+        store.cycleLength = 7
+
+        store.assignProductToCycleSlot(productId: toner.id, dayIndex: 0, routineType: .morning)
+        store.assignProductToCycleSlot(productId: cream.id, dayIndex: 0, routineType: .morning)
+        store.assignProductToCycleSlot(productId: wasOther.id, dayIndex: 0, routineType: .morning)
+
+        XCTAssertEqual(
+            store.cycleProductOrder,
+            [toner.id, cream.id, wasOther.id],
+            "Other (order 99) should trail cream (7)"
+        )
+
+        var updated = wasOther
+        updated.categoryId = "serum"
+        store.updateProduct(updated)
+
+        // Without repositioning on Other→specific category, `cycleProductOrder` stays insertion order
+        // (toner → cream → wasOther) even though the product is now serum and should precede cream.
+        XCTAssertNotEqual(
+            store.cycleProductOrder,
+            [toner.id, cream.id, wasOther.id],
+            "Regression guard: unfixed behavior leaves stale [toner, cream, product] at end"
+        )
+        XCTAssertEqual(
+            store.cycleProductOrder,
+            [toner.id, wasOther.id, cream.id],
+            "Serum (4) should sort before cream (7)"
+        )
+
+        let slotProducts = store.productsOnCycleSlot(dayIndex: 0, routineType: .morning)
+            .compactMap { store.product(by: $0) }
+        let orderedNames = store.productsSortedByCycleOrder(slotProducts).map(\.name)
+        XCTAssertEqual(orderedNames, ["Toner", "Mystery", "Cream"])
+
+        XCTAssertEqual(
+            store.morningRoutine.productIds,
+            [toner.id, wasOther.id, cream.id],
+            "Saved routine list should match new category order"
+        )
+    }
+
     func testApplyCycleToRoutines_emptyCycle_clearsRoutines() throws {
         let product = Product(name: "Serum", ingredientNames: [])
         store.addProduct(product)

--- a/SkincareTrackerTests/HealthKitAccessTests.swift
+++ b/SkincareTrackerTests/HealthKitAccessTests.swift
@@ -2,15 +2,13 @@
 //  HealthKitAccessTests.swift
 //  SkincareTrackerTests
 //
-//  Verifies that HealthKit authorization is triggered in onboarding and when toggling
-//  "Use Health bedtime" or "Use Health wake time" in Reminders.
-//  Uses ViewInspector for OnboardingView; RemindersView uses hosting + mock continuation (ViewInspector blocks on EnvObj).
+//  Verifies HealthKit authorization: onboarding Health sleep sync path, and Reminders
+//  when "Use Health bedtime" / "Use Health wake time" are on. RemindersView uses hosting + mock continuation.
 //
 
 import XCTest
 import SwiftUI
 import UIKit
-import ViewInspector
 @testable import SkincareTracker
 
 // MARK: - HealthKit Call Counting
@@ -139,14 +137,18 @@ final class HealthKitAccessTests: XCTestCase {
         _ = hosting.view
     }
 
-    /// Forces OnboardingView body evaluation. OnboardingView has no onAppear for Health; this just ensures view is built.
-    private func triggerOnboardingOnAppear<V: View>(_ view: V) throws {
-        _ = try view.inspect()
+    /// Hosts OnboardingView so onAppear fires. For unavailable HealthKit, run briefly; for available, waits for mock call.
+    private func hostOnboardingView(_ view: some View) {
+        let hosting = UIHostingController(rootView: view)
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 375, height: 812))
+        window.rootViewController = hosting
+        window.makeKeyAndVisible()
+        _ = hosting.view
     }
 
     // MARK: - Onboarding
 
-    func testOnboarding_onAppear_doesNotTriggerRequestAuthorization() throws {
+    func testOnboarding_onAppear_doesNotTriggerHealthAuthorization() throws {
         let (store, reminderService) = try requireDependencies()
         let mock = MockHealthKitService()
         let view = OnboardingView(onComplete: {})
@@ -154,7 +156,8 @@ final class HealthKitAccessTests: XCTestCase {
             .environmentObject(reminderService)
             .environmentObject(mock as HealthKitServiceBase)
 
-        try triggerOnboardingOnAppear(view)
+        hostOnboardingView(view)
+        RunLoop.current.run(until: Date().addingTimeInterval(0.15))
 
         XCTAssertEqual(
             mock.requestAuthorizationCallCount, 0,
@@ -162,22 +165,12 @@ final class HealthKitAccessTests: XCTestCase {
         )
     }
 
-    func testOnboarding_allowHealthAccessButton_triggersRequestAuthorization() async throws {
-        let (store, reminderService) = try requireDependencies()
+    func testOnboarding_performHealthAuthorizationRequest_matchesHealthSleepSyncTogglePath() async throws {
         let mock = MockHealthKitService()
-        let healthAccessAction: () async -> Void = { try? await mock.requestAuthorization() }
-        _ = OnboardingView(onComplete: {})
-            .environmentObject(store)
-            .environmentObject(reminderService)
-            .environmentObject(mock as HealthKitServiceBase)
-            .environment(\.healthAccessRequestAction, healthAccessAction)
-
-        // Invoke the button's action directly (injected). This avoids relying on accessibilityActivate(),
-        // which does not guarantee the SwiftUI button's action fires.
-        await healthAccessAction()
+        await OnboardingView.performHealthAuthorizationRequest(healthKitService: mock)
         XCTAssertEqual(
             mock.requestAuthorizationCallCount, 1,
-            "Allow Health Access button action should trigger request exactly once (not multiple times)"
+            "Same code path as enabling Sync with Health sleep schedule in onboarding"
         )
     }
 
@@ -189,28 +182,19 @@ final class HealthKitAccessTests: XCTestCase {
             .environmentObject(reminderService)
             .environmentObject(mock as HealthKitServiceBase)
 
-        try triggerOnboardingOnAppear(view)
+        hostOnboardingView(view)
+        RunLoop.current.run(until: Date().addingTimeInterval(0.15))
 
         XCTAssertEqual(
             mock.requestAuthorizationCallCount, 0,
-            "When HealthKit is unavailable, onboarding should not call requestAuthorization (no Health section shown)"
+            "When HealthKit is unavailable, onboarding does not request Health (no Health sync toggle)"
         )
     }
 
-    func testOnboarding_requestAuthorizationThrowing_doesNotCrash() async throws {
-        let (store, reminderService) = try requireDependencies()
+    func testOnboarding_performHealthAuthorizationRequest_throwing_doesNotCrash() async throws {
         let mock = MockHealthKitServiceThrowing()
-        let healthAccessAction: () async -> Void = { try? await mock.requestAuthorization() }
-        _ = OnboardingView(onComplete: {})
-            .environmentObject(store)
-            .environmentObject(reminderService)
-            .environmentObject(mock as HealthKitServiceBase)
-            .environment(\.healthAccessRequestAction, healthAccessAction)
-
-        // Smoke test only: invoke the action directly, verify mock was called and process survived.
-        // The view uses try? so there is no error UI to assert on.
-        await healthAccessAction()
-        XCTAssertEqual(mock.requestAuthorizationCallCount, 1)
+        await OnboardingView.performHealthAuthorizationRequest(healthKitService: mock)
+        XCTAssertEqual(mock.requestAuthorizationCallCount, 1, "try? swallows throw; no crash")
     }
 
     // MARK: - Reminders - Use Health Bedtime / Wake Time

--- a/SkincareTrackerTests/ViewRenderingTests.swift
+++ b/SkincareTrackerTests/ViewRenderingTests.swift
@@ -9,6 +9,7 @@
 import XCTest
 import SwiftUI
 import UIKit
+import ViewInspector
 @testable import SkincareTracker
 
 @MainActor
@@ -62,6 +63,24 @@ final class ViewRenderingTests: XCTestCase {
         XCTAssertEqual(CycleViewLayout.productListRowHeight, 58, "Row height must be 58 to prevent last product from being cut off")
     }
 
+    /// When a product is added via AddToCycleSheet but not yet assigned to any routine, it must appear
+    /// in the product list so the user can assign it. This fails if the view uses productsInCycle.isEmpty
+    /// (assigned-only) instead of productsInCycleOrdered.isEmpty (includes unassigned "staged" products).
+    func testCycleView_productAddedButUnassigned_appearsInProductList() throws {
+        let product = Product(name: "StagedSerum", ingredientNames: [])
+        store.addProduct(product)
+        store.addProductToCycle(product)
+        // No assignProductToCycleSlot — all routines remain empty; product is in cycleProductOrder only
+
+        XCTAssertTrue(store.productsInCycleOrdered.contains(where: { $0.name == "StagedSerum" }))
+        XCTAssertTrue(store.productsInCycle.isEmpty, "Product should not be in productsInCycle when unassigned")
+
+        let cycleView = CycleView().environmentObject(store).environmentObject(savedBanner)
+        _ = try cycleView.inspect().find(viewWithAccessibilityIdentifier: "cycle-product-list")
+        // If we get here, the product list is shown. If the fix were reverted (productsInCycle.isEmpty),
+        // the empty state would be shown instead and find would throw.
+    }
+
     func testProductsView_renders() throws {
         render(ProductsView().environmentObject(store).environmentObject(savedBanner))
     }
@@ -85,11 +104,12 @@ final class ViewRenderingTests: XCTestCase {
     }
 
     func testRemindersView_renders() throws {
+        let health = HealthKitService()
         render(
             RemindersView()
                 .environmentObject(store)
                 .environmentObject(ReminderService())
-                .environmentObject(HealthKitService())
+                .environmentObject(health as HealthKitServiceBase)
         )
     }
 

--- a/SkincareTrackerTests/ViewRenderingTests.swift
+++ b/SkincareTrackerTests/ViewRenderingTests.swift
@@ -51,6 +51,17 @@ final class ViewRenderingTests: XCTestCase {
         render(CycleView().environmentObject(store).environmentObject(savedBanner))
     }
 
+    func testCycleView_withManyProducts_rendersAllRows() throws {
+        for i in 1...10 {
+            let product = Product(name: "Product \(i)", ingredientNames: [])
+            store.addProduct(product)
+            store.addProductToCycle(product)
+        }
+        render(CycleView().environmentObject(store).environmentObject(savedBanner))
+        XCTAssertEqual(store.productsInCycleOrdered.count, 10)
+        XCTAssertEqual(CycleViewLayout.productListRowHeight, 58, "Row height must be 58 to prevent last product from being cut off")
+    }
+
     func testProductsView_renders() throws {
         render(ProductsView().environmentObject(store).environmentObject(savedBanner))
     }


### PR DESCRIPTION
fix:

- persistence
- healthkit
- - [ ] when you add a product to the products list in cycle view, then without adding it to any routine navigate to the productsview, you temporarily see two of the product you added for a split second
- - [x] if a user changes or sets the category of a product from other to something else through the product view, the order should update in the routine. “other” is the default category, so when the user sets it to a specific category that is not “other”, it should change the order of the products in routines.
- - [x] The last product in the list of products in CycleView occasionally gets cut off so that only the top half is visible.