### PR TITLE
fix reminders

### DIFF
--- a/SkincareTracker/Services/ReminderService.swift
+++ b/SkincareTracker/Services/ReminderService.swift
@@ -13,6 +13,64 @@ import UserNotifications
 final class ReminderService: ObservableObject {
     private let center = UNUserNotificationCenter.current()
 
+    static let reminderHorizonDays = 60
+
+    static let reminderRequestIdentifierPrefix = "skincare.routine."
+
+    private static let lastRollForwardDayKey = "com.skincaretracker.lastReminderRollForwardDay"
+
+    struct PlannedReminderEntry {
+        let identifier: String
+        let title: String
+        let body: String
+        let noRoutine: Bool
+        let dateComponents: DateComponents
+        let repeats: Bool
+    }
+
+    /// Computes pending notifications for the horizon. Used by `rescheduleReminders` and tests to ensure each day’s body matches that day’s cycle (morning and night).
+    static func plannedReminderEntries(
+        configs: [ReminderConfig],
+        productsForDate: (Date, RoutineType) -> [Product],
+        healthWakeTime: (hour: Int, minute: Int)?,
+        healthBedtime: (hour: Int, minute: Int)?,
+        todayStart: Date,
+        now: Date,
+        calendar: Calendar,
+        horizonDays: Int
+    ) -> [PlannedReminderEntry] {
+        var entries: [PlannedReminderEntry] = []
+        for dayOffset in 0..<horizonDays {
+            guard let dayDate = calendar.date(byAdding: .day, value: dayOffset, to: todayStart) else { continue }
+            for config in configs where config.isEnabled {
+                let products = productsForDate(dayDate, config.routineType)
+                let params = Self.buildNotificationParameters(
+                    config: config,
+                    products: products,
+                    healthWakeTime: healthWakeTime,
+                    healthBedtime: healthBedtime
+                )
+                var dateComponents = calendar.dateComponents([.year, .month, .day], from: dayDate)
+                dateComponents.hour = params.hour
+                dateComponents.minute = params.minute
+                guard let fireDate = calendar.date(from: dateComponents), fireDate > now else { continue }
+
+                let identifier = Self.reminderRequestIdentifier(routineType: config.routineType, dayStart: dayDate, calendar: calendar)
+                entries.append(
+                    PlannedReminderEntry(
+                        identifier: identifier,
+                        title: params.title,
+                        body: params.body,
+                        noRoutine: products.isEmpty,
+                        dateComponents: dateComponents,
+                        repeats: false
+                    )
+                )
+            }
+        }
+        return entries
+    }
+
     /// Request notification permission. Call before scheduling.
     func requestPermission() async -> Bool {
         let settings = await center.notificationSettings()
@@ -21,45 +79,106 @@ final class ReminderService: ObservableObject {
         return granted ?? false
     }
 
-    /// Clears all pending skincare reminders and reschedules based on config and store.
+    /// Fetches Health sleep times when enabled and reschedules local notifications.
+    func rescheduleAllReminders(store: AppStore, healthKit: HealthKitServiceBase) async {
+        var healthWakeTime: (hour: Int, minute: Int)?
+        var healthBedtime: (hour: Int, minute: Int)?
+        let morningConfig = store.reminderConfig(for: .morning)
+        let nightConfig = store.reminderConfig(for: .night)
+        if (morningConfig.useHealthWakeTime && morningConfig.isEnabled) || (nightConfig.useHealthBedtime && nightConfig.isEnabled) {
+            try? await healthKit.requestAuthorization()
+            if morningConfig.useHealthWakeTime, morningConfig.isEnabled {
+                healthWakeTime = await healthKit.fetchTypicalWakeTime()
+            }
+            if nightConfig.useHealthBedtime, nightConfig.isEnabled {
+                healthBedtime = await healthKit.fetchTypicalBedtime()
+            }
+        }
+        await rescheduleReminders(
+            configs: store.reminderConfigs,
+            productsForDate: { store.productsForDate($0, routineType: $1) },
+            healthWakeTime: healthWakeTime,
+            healthBedtime: healthBedtime
+        )
+    }
+
+    /// Reschedules once per calendar day when the app becomes active so the rolling window stays ahead of the clock.
+    func rollRemindersForwardIfNeeded(store: AppStore, healthKit: HealthKitServiceBase) async {
+        let calendar = Calendar.current
+        let todayStart = calendar.startOfDay(for: Date())
+        let fmt = DateFormatter()
+        fmt.calendar = calendar
+        fmt.locale = Locale(identifier: "en_US_POSIX")
+        fmt.timeZone = calendar.timeZone
+        fmt.dateFormat = "yyyy-MM-dd"
+        let dayKey = fmt.string(from: todayStart)
+        if UserDefaults.standard.string(forKey: Self.lastRollForwardDayKey) == dayKey { return }
+        guard store.reminderConfigs.contains(where: \.isEnabled) else { return }
+        guard await requestPermission() else { return }
+        await rescheduleAllReminders(store: store, healthKit: healthKit)
+        UserDefaults.standard.set(dayKey, forKey: Self.lastRollForwardDayKey)
+    }
+
+    /// Clears pending skincare reminders and schedules one non-repeating notification per day in the horizon for each enabled routine.
     func rescheduleReminders(
         configs: [ReminderConfig],
         productsForDate: (Date, RoutineType) -> [Product],
         healthWakeTime: (hour: Int, minute: Int)?,
         healthBedtime: (hour: Int, minute: Int)?
     ) async {
-        center.removePendingNotificationRequests(withIdentifiers: ["morning", "night"])
+        await removePendingSkincareRoutineReminders()
         guard await requestPermission() else { return }
 
         let calendar = Calendar.current
         let todayStart = calendar.startOfDay(for: Date())
-
-        for config in configs where config.isEnabled {
-            let products = productsForDate(todayStart, config.routineType)
-            let params = Self.buildNotificationParameters(
-                config: config,
-                products: products,
-                healthWakeTime: healthWakeTime,
-                healthBedtime: healthBedtime
-            )
+        let now = Date()
+        let planned = Self.plannedReminderEntries(
+            configs: configs,
+            productsForDate: productsForDate,
+            healthWakeTime: healthWakeTime,
+            healthBedtime: healthBedtime,
+            todayStart: todayStart,
+            now: now,
+            calendar: calendar,
+            horizonDays: Self.reminderHorizonDays
+        )
+        for entry in planned {
             let content = UNMutableNotificationContent()
-            content.title = params.title
-            content.body = params.body
+            content.title = entry.title
+            content.body = entry.body
             content.sound = .default
-            if products.isEmpty {
+            if entry.noRoutine {
                 content.userInfo = ["noRoutine": true]
             }
-            var dateComponents = DateComponents()
-            dateComponents.hour = params.hour
-            dateComponents.minute = params.minute
-            let trigger = UNCalendarNotificationTrigger(dateMatching: dateComponents, repeats: true)
+            let trigger = UNCalendarNotificationTrigger(dateMatching: entry.dateComponents, repeats: entry.repeats)
             let request = UNNotificationRequest(
-                identifier: params.identifier,
+                identifier: entry.identifier,
                 content: content,
                 trigger: trigger
             )
             try? await center.add(request)
         }
+    }
+
+    private func removePendingSkincareRoutineReminders() async {
+        let pending = await withCheckedContinuation { (cont: CheckedContinuation<[UNNotificationRequest], Never>) in
+            center.getPendingNotificationRequests { cont.resume(returning: $0) }
+        }
+        var ids = pending.map(\.identifier).filter { $0.hasPrefix(Self.reminderRequestIdentifierPrefix) }
+        ids.append(contentsOf: ["morning", "night"])
+        center.removePendingNotificationRequests(withIdentifiers: ids)
+    }
+
+    /// Stable per-day identifier for a routine reminder (used instead of repeating `morning` / `night` ids).
+    static func reminderRequestIdentifier(routineType: RoutineType, dayStart: Date, calendar: Calendar) -> String {
+        let day = calendar.startOfDay(for: dayStart)
+        let fmt = DateFormatter()
+        fmt.calendar = calendar
+        fmt.locale = Locale(identifier: "en_US_POSIX")
+        fmt.timeZone = calendar.timeZone
+        fmt.dateFormat = "yyyy-MM-dd"
+        let tag = routineType == .morning ? "morning" : "night"
+        return "\(reminderRequestIdentifierPrefix)\(tag).\(fmt.string(from: day))"
     }
 
     /// Builds notification parameters (body, title, hour, minute) for testing.

--- a/SkincareTracker/Views/ContentView.swift
+++ b/SkincareTracker/Views/ContentView.swift
@@ -72,6 +72,13 @@ struct ContentView: View {
         .onChange(of: scenePhase) { _, newPhase in
             if newPhase == .background {
                 store.saveToDisk()
+            } else if newPhase == .active, !showOnboarding {
+                Task {
+                    await reminderService.rollRemindersForwardIfNeeded(
+                        store: store,
+                        healthKit: healthKitService as HealthKitServiceBase
+                    )
+                }
             }
         }
         .foregroundStyle(AppColors.textPrimary)

--- a/SkincareTracker/Views/Onboarding/OnboardingView.swift
+++ b/SkincareTracker/Views/Onboarding/OnboardingView.swift
@@ -198,25 +198,7 @@ struct OnboardingView: View {
     }
 
     private func rescheduleReminders() async {
-        var healthWakeTime: (hour: Int, minute: Int)? = nil
-        var healthBedtime: (hour: Int, minute: Int)? = nil
-        let morningConfig = store.reminderConfig(for: .morning)
-        let nightConfig = store.reminderConfig(for: .night)
-        if (morningConfig.useHealthWakeTime && morningConfig.isEnabled) || (nightConfig.useHealthBedtime && nightConfig.isEnabled) {
-            try? await healthKitService.requestAuthorization()
-            if morningConfig.useHealthWakeTime, morningConfig.isEnabled {
-                healthWakeTime = await healthKitService.fetchTypicalWakeTime()
-            }
-            if nightConfig.useHealthBedtime, nightConfig.isEnabled {
-                healthBedtime = await healthKitService.fetchTypicalBedtime()
-            }
-        }
-        await reminderService.rescheduleReminders(
-            configs: store.reminderConfigs,
-            productsForDate: { store.productsForDate($0, routineType: $1) },
-            healthWakeTime: healthWakeTime,
-            healthBedtime: healthBedtime
-        )
+        await reminderService.rescheduleAllReminders(store: store, healthKit: healthKitService)
     }
 
     static let onboardingCompleteKey = "com.skincaretracker.onboardingComplete"

--- a/SkincareTracker/Views/Reminders/RemindersView.swift
+++ b/SkincareTracker/Views/Reminders/RemindersView.swift
@@ -50,25 +50,7 @@ struct RemindersView: View {
     }
 
     private func rescheduleReminders() async {
-        var healthWakeTime: (hour: Int, minute: Int)? = nil
-        var healthBedtime: (hour: Int, minute: Int)? = nil
-        let morningConfig = store.reminderConfig(for: .morning)
-        let nightConfig = store.reminderConfig(for: .night)
-        if (morningConfig.useHealthWakeTime && morningConfig.isEnabled) || (nightConfig.useHealthBedtime && nightConfig.isEnabled) {
-            try? await healthKitService.requestAuthorization()
-            if morningConfig.useHealthWakeTime, morningConfig.isEnabled {
-                healthWakeTime = await healthKitService.fetchTypicalWakeTime()
-            }
-            if nightConfig.useHealthBedtime, nightConfig.isEnabled {
-                healthBedtime = await healthKitService.fetchTypicalBedtime()
-            }
-        }
-        await reminderService.rescheduleReminders(
-            configs: store.reminderConfigs,
-            productsForDate: { store.productsForDate($0, routineType: $1) },
-            healthWakeTime: healthWakeTime,
-            healthBedtime: healthBedtime
-        )
+        await reminderService.rescheduleAllReminders(store: store, healthKit: healthKitService)
     }
 }
 

--- a/SkincareTrackerTests/ReminderServiceTests.swift
+++ b/SkincareTrackerTests/ReminderServiceTests.swift
@@ -204,6 +204,180 @@ final class ReminderServiceTests: XCTestCase {
         XCTAssertEqual(params.minute, 30, "Morning uses Health wake time when useHealthWakeTime is true")
     }
 
+    // MARK: - Per-calendar-day bodies (cycle day advances; morning & night)
+
+    /// Fixed clock + calendar so planned fire times are stable. Morning 08:00 and night 21:00; `now` is day 0 at 06:00 so the first two days schedule.
+    private func makeFixedCalendarAndAnchors() -> (calendar: Calendar, todayStart: Date, day1: Date, now: Date) {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        let todayStart = calendar.date(from: DateComponents(year: 2020, month: 6, day: 15))!
+        let day1 = calendar.date(byAdding: .day, value: 1, to: todayStart)!
+        let now = calendar.date(byAdding: .hour, value: 6, to: todayStart)!
+        return (calendar, todayStart, day1, now)
+    }
+
+    /// Returns different product names per calendar day and routine so we can detect “frozen day 0” bugs.
+    private func productsForDateCycleStub(
+        calendar: Calendar,
+        todayStart: Date,
+        day1: Date,
+        date: Date,
+        routineType: RoutineType
+    ) -> [Product] {
+        let day = calendar.startOfDay(for: date)
+        switch (day, routineType) {
+        case (todayStart, .morning):
+            return [Product(name: "AM-Day0")]
+        case (todayStart, .night):
+            return [Product(name: "PM-Day0")]
+        case (day1, .morning):
+            return [Product(name: "AM-Day1")]
+        case (day1, .night):
+            return [Product(name: "PM-Day1")]
+        default:
+            return []
+        }
+    }
+
+    func testPlannedReminderEntries_morningAndNightUseProductsForEachCalendarDay() {
+        let (calendar, todayStart, day1, now) = makeFixedCalendarAndAnchors()
+        let morningConfig = ReminderConfig(routineType: .morning, hour: 8, minute: 0, isEnabled: true)
+        let nightConfig = ReminderConfig(routineType: .night, hour: 21, minute: 0, isEnabled: true)
+        let configs = [morningConfig, nightConfig]
+
+        let productsForDate: (Date, RoutineType) -> [Product] = { date, routineType in
+            self.productsForDateCycleStub(calendar: calendar, todayStart: todayStart, day1: day1, date: date, routineType: routineType)
+        }
+
+        let entries = ReminderService.plannedReminderEntries(
+            configs: configs,
+            productsForDate: productsForDate,
+            healthWakeTime: nil,
+            healthBedtime: nil,
+            todayStart: todayStart,
+            now: now,
+            calendar: calendar,
+            horizonDays: 2
+        )
+
+        let idM0 = ReminderService.reminderRequestIdentifier(routineType: .morning, dayStart: todayStart, calendar: calendar)
+        let idN0 = ReminderService.reminderRequestIdentifier(routineType: .night, dayStart: todayStart, calendar: calendar)
+        let idM1 = ReminderService.reminderRequestIdentifier(routineType: .morning, dayStart: day1, calendar: calendar)
+        let idN1 = ReminderService.reminderRequestIdentifier(routineType: .night, dayStart: day1, calendar: calendar)
+
+        guard let m0 = entries.first(where: { $0.identifier == idM0 }),
+              let n0 = entries.first(where: { $0.identifier == idN0 }),
+              let m1 = entries.first(where: { $0.identifier == idM1 }),
+              let n1 = entries.first(where: { $0.identifier == idN1 }) else {
+            XCTFail("Expected four entries for two days × morning & night; got: \(entries.map(\.identifier))")
+            return
+        }
+
+        let expectedM0 = ReminderService.buildNotificationParameters(
+            config: morningConfig,
+            products: productsForDate(todayStart, .morning),
+            healthWakeTime: nil,
+            healthBedtime: nil
+        ).body
+        let expectedN0 = ReminderService.buildNotificationParameters(
+            config: nightConfig,
+            products: productsForDate(todayStart, .night),
+            healthWakeTime: nil,
+            healthBedtime: nil
+        ).body
+        let expectedM1 = ReminderService.buildNotificationParameters(
+            config: morningConfig,
+            products: productsForDate(day1, .morning),
+            healthWakeTime: nil,
+            healthBedtime: nil
+        ).body
+        let expectedN1 = ReminderService.buildNotificationParameters(
+            config: nightConfig,
+            products: productsForDate(day1, .night),
+            healthWakeTime: nil,
+            healthBedtime: nil
+        ).body
+
+        XCTAssertEqual(m0.body, expectedM0)
+        XCTAssertEqual(n0.body, expectedN0)
+        XCTAssertEqual(m1.body, expectedM1)
+        XCTAssertEqual(n1.body, expectedN1)
+
+        XCTAssertEqual(m0.repeats, false)
+        XCTAssertEqual(n0.repeats, false)
+        XCTAssertNotEqual(expectedM0, expectedM1, "fixture: day 0 and day 1 morning must differ")
+        XCTAssertNotEqual(expectedN0, expectedN1, "fixture: day 0 and day 1 night must differ")
+    }
+
+    /// Regression: the old implementation used `productsForDate(todayStart, …)` for the notification body with a *repeating* trigger, so day 2 of the cycle still showed day 1’s product list. Planned entries for day 1 must not match bodies derived only from `todayStart`.
+    func testPlannedReminderEntries_day1BodiesDifferFromFrozenTodayStartBodies() {
+        let (calendar, todayStart, day1, now) = makeFixedCalendarAndAnchors()
+        let morningConfig = ReminderConfig(routineType: .morning, hour: 8, minute: 0, isEnabled: true)
+        let nightConfig = ReminderConfig(routineType: .night, hour: 21, minute: 0, isEnabled: true)
+
+        let productsForDate: (Date, RoutineType) -> [Product] = { date, routineType in
+            self.productsForDateCycleStub(calendar: calendar, todayStart: todayStart, day1: day1, date: date, routineType: routineType)
+        }
+
+        let frozenTodayMorningBody = ReminderService.buildNotificationParameters(
+            config: morningConfig,
+            products: productsForDate(todayStart, .morning),
+            healthWakeTime: nil,
+            healthBedtime: nil
+        ).body
+        let frozenTodayNightBody = ReminderService.buildNotificationParameters(
+            config: nightConfig,
+            products: productsForDate(todayStart, .night),
+            healthWakeTime: nil,
+            healthBedtime: nil
+        ).body
+
+        let entries = ReminderService.plannedReminderEntries(
+            configs: [morningConfig, nightConfig],
+            productsForDate: productsForDate,
+            healthWakeTime: nil,
+            healthBedtime: nil,
+            todayStart: todayStart,
+            now: now,
+            calendar: calendar,
+            horizonDays: 2
+        )
+
+        let idM1 = ReminderService.reminderRequestIdentifier(routineType: .morning, dayStart: day1, calendar: calendar)
+        let idN1 = ReminderService.reminderRequestIdentifier(routineType: .night, dayStart: day1, calendar: calendar)
+        let m1 = entries.first { $0.identifier == idM1 }
+        let n1 = entries.first { $0.identifier == idN1 }
+
+        XCTAssertNotEqual(m1?.body, frozenTodayMorningBody, "Day 1 morning notification must not reuse day 0’s product list.")
+        XCTAssertNotEqual(n1?.body, frozenTodayNightBody, "Day 1 night notification must not reuse day 0’s product list.")
+    }
+
+    /// The pre-fix design scheduled only two repeating requests (`morning` / `night`), so the body never updated. We require one non-repeating request per calendar day per routine.
+    func testPlannedReminderEntries_twoCalendarDaysScheduleFourNonRepeatingRequests() {
+        let (calendar, todayStart, day1, now) = makeFixedCalendarAndAnchors()
+        let morningConfig = ReminderConfig(routineType: .morning, hour: 8, minute: 0, isEnabled: true)
+        let nightConfig = ReminderConfig(routineType: .night, hour: 21, minute: 0, isEnabled: true)
+        let productsForDate: (Date, RoutineType) -> [Product] = { date, routineType in
+            self.productsForDateCycleStub(calendar: calendar, todayStart: todayStart, day1: day1, date: date, routineType: routineType)
+        }
+
+        let entries = ReminderService.plannedReminderEntries(
+            configs: [morningConfig, nightConfig],
+            productsForDate: productsForDate,
+            healthWakeTime: nil,
+            healthBedtime: nil,
+            todayStart: todayStart,
+            now: now,
+            calendar: calendar,
+            horizonDays: 2
+        )
+
+        XCTAssertEqual(entries.count, 4, "Expected 2 days × 2 routines")
+        XCTAssertTrue(entries.allSatisfy { !$0.repeats })
+        let ids = Set(entries.map(\.identifier))
+        XCTAssertEqual(ids.count, 4, "Each scheduled notification should have a unique identifier")
+    }
+
     // MARK: - Integration-style (rescheduleReminders doesn't crash)
 
     func testRescheduleReminders_withDisabledConfigs_doesNotThrow() async throws {


### PR DESCRIPTION
Repeating UNCalendarNotificationTrigger requests froze notification bodies from the day reminders were last scheduled. Schedule non-repeating per-calendar-day notifications for a rolling horizon instead, and roll forward when the app becomes active.

- ReminderService: plannedReminderEntries, rescheduleAllReminders, roll forward
- ContentView: refresh reminders on scene active (throttled daily)
- Onboarding + Reminders: shared rescheduleAllReminders path
- ReminderServiceTests: regression tests for per-day bodies